### PR TITLE
chore: JaCoCo와 SonarCloud를 연동한 Gradle 빌드 및 품질 관리 시스템 구축

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew fullCheck --parallel --build-cache --info
+        run: ./gradlew fullCheck --parallel --build-cache --debug

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build-validation:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -44,8 +44,18 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
 
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Run Gradle check (fast validation)
-        run: ./gradlew check --parallel --build-cache
+      - name: Run full check and SonarCloud analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew fullCheck --parallel --build-cache --info

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew fullCheck --parallel --build-cache --stacktrace
+        run: ./gradlew fullCheck --parallel --build-cache --info --stacktrace

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew fullCheck --parallel --build-cache --debug
+        run: ./gradlew fullCheck --parallel --build-cache --info

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew fullCheck --parallel --build-cache --info
+        run: ./gradlew fullCheck --parallel --build-cache --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     kotlin(Plugins.Kotlin.Short.SPRING) version Versions.KOTLIN
     kotlin(Plugins.Kotlin.Short.JPA) version Versions.KOTLIN
     id(Plugins.DETEKT) version Versions.DETEKT
-    id(Plugins.KOVER) version Versions.KOVER
     id(Plugins.JACOCO)
     id(Plugins.SONAR_QUBE) version Versions.SONAR_QUBE
 }
@@ -111,6 +110,10 @@ configure(subprojects) {
                 exclude(testExclusionPatterns)
             }
         }))
+
+        executionData.setFrom(fileTree(layout.buildDirectory) {
+            include("jacoco/*.exec")
+        })
     }
 }
 
@@ -133,8 +136,10 @@ tasks.register<JacocoReport>("jacocoRootReport") {
             exclude(testExclusionPatterns)
         }
     })
-    executionData.from(subprojects.map {
-        it.layout.buildDirectory.file("jacoco/test.exec")
+    executionData.from(subprojects.map { subproject ->
+        subproject.fileTree(subproject.layout.buildDirectory.dir("jacoco")) {
+            include("*.exec")
+        }
     })
 
     reports {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,7 +137,7 @@ tasks.register<JacocoReport>("jacocoRootReport") {
     })
     executionData.from(subprojects.map { subproject ->
         subproject.fileTree(subproject.layout.buildDirectory.dir("jacoco")) {
-            include("*.exec")
+            include("**/*.exec")
         }
     })
 
@@ -159,16 +159,22 @@ configure<SonarExtension> {
             "${layout.buildDirectory.get()}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
         )
 
-        property("sonar.sources", subprojects.joinToString(",") { "${it.projectDir}/src/main" })
-        property("sonar.tests", subprojects.joinToString(",") { "${it.projectDir}/src/test" })
+        property("sonar.sources", subprojects.joinToString(",") { "${it.projectDir}/src/main/kotlin" })
+        property("sonar.tests", subprojects.joinToString(",") { "${it.projectDir}/src/test/kotlin" })
+
         property("sonar.java.binaries", subprojects.joinToString(",") {
             "${it.layout.buildDirectory.get()}/classes/kotlin/main"
         })
+        property("sonar.java.test.binaries", subprojects.joinToString(",") {
+            "${it.layout.buildDirectory.get()}/classes/kotlin/test"
+        })
 
-        property("sonar.kotlin.source.version", Versions.KOTLIN)
+        property("sonar.kotlin.version", Versions.KOTLIN)
         property("sonar.exclusions", sonarGlobalExclusions.joinToString(","))
         property("sonar.cpd.exclusions", testExclusionPatterns.joinToString(","))
         property("sonar.coverage.exclusions", testExclusionPatterns.joinToString(","))
+
+        property("sonar.test.inclusions", "**/*Test.kt:**/*Tests.kt:**/*Spec.kt")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,12 +133,8 @@ tasks.register<JacocoReport>("jacocoRootReport") {
             exclude(testExclusionPatterns)
         }
     })
-    executionData.setFrom(subprojects.mapNotNull { subproject ->
-        val execFile = subproject.tasks.named<JacocoReport>("jacocoTestReport").get().executionData.singleFile
-        execFile.takeIf { file -> file.exists() } ?: run {
-            logger.warn("JaCoCo execution data not found for ${subproject.name}: ${execFile.absolutePath}")
-            null
-        }
+    executionData.from(subprojects.map {
+        it.layout.buildDirectory.file("jacoco/test.exec")
     })
 
     reports {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.sonarqube.gradle.SonarExtension
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
@@ -147,7 +146,7 @@ tasks.register<JacocoReport>("jacocoRootReport") {
 }
 
 // SonarQube 설정을 루트에서 모든 서브모듈에 대해 설정
-configure<SonarExtension> {
+sonar {
     properties {
         property("sonar.projectKey", "YAPP-Github_26th-App-Team-1-BE")
         property("sonar.organization", "yapp-github")
@@ -157,15 +156,10 @@ configure<SonarExtension> {
             "${layout.buildDirectory.get()}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
         )
 
-        property("sonar.sources", subprojects.joinToString(",") { "${it.projectDir}/src/main/kotlin" })
-        property("sonar.tests", subprojects.joinToString(",") { "${it.projectDir}/src/test/kotlin" })
-
-        property("sonar.java.binaries", subprojects.joinToString(",") {
-            "${it.layout.buildDirectory.get()}/classes/kotlin/main"
-        })
-        property("sonar.java.test.binaries", subprojects.joinToString(",") {
-            "${it.layout.buildDirectory.get()}/classes/kotlin/test"
-        })
+        // property("sonar.sources", subprojects.joinToString(",") { "${it.projectDir}/src/main/kotlin" })
+        // property("sonar.tests", subprojects.joinToString(",") { "${it.projectDir}/src/test/kotlin" })
+        // property("sonar.java.binaries", subprojects.joinToString(",") { "${it.layout.buildDirectory.get()}/classes/kotlin/main" })
+        // property("sonar.java.test.binaries", subprojects.joinToString(",") { "${it.layout.buildDirectory.get()}/classes/kotlin/test" })
 
         property("sonar.kotlin.version", Versions.KOTLIN)
         property("sonar.exclusions", sonarGlobalExclusions.joinToString(","))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ subprojects {
     // Configure Kotlin compiler options
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         kotlinOptions {
-            freeCompilerArgs = listOf(
+            freeCompilerArgs += listOf(
                 "-Xjsr305=strict",
                 "-Xconsistent-data-class-copy-visibility"
             )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,16 +22,16 @@ allprojects {
 
 // 테스트하지 않는 코드 패턴 (JaCoCo + SonarQube 커버리지 + CPD 공통)
 val testExclusionPatterns = listOf(
-    "**/*Application.kt",
+    "**/*Application*",
     "**/config/**",
-    "**/*Config.kt",
+    "**/*Config*",
     "**/exception/**",
-    "**/*Exception.kt",
-    "**/*ErrorCode.kt",
+    "**/*Exception*",
+    "**/*ErrorCode*",
     "**/dto/**",
-    "**/*Request.kt",
-    "**/*Response.kt",
-    "**/*Entity.kt",
+    "**/*Request*",
+    "**/*Response*",
+    "**/*Entity*",
     "**/annotation/**",
     "**/generated/**"
 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,10 +55,6 @@ subprojects {
         }
     }
 
-    tasks.withType<Test> {
-        useJUnitPlatform()
-    }
-
     plugins.withId(Plugins.Kotlin.ALLOPEN) {
         extensions.configure<org.jetbrains.kotlin.allopen.gradle.AllOpenExtension> {
             annotation("jakarta.persistence.Entity")
@@ -86,6 +82,7 @@ configure(subprojects) {
     }
 
     tasks.withType<Test> {
+        useJUnitPlatform()
         finalizedBy("jacocoTestReport")
 
         testLogging {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,12 +155,7 @@ sonar {
             "sonar.coverage.jacoco.xmlReportPaths",
             "${layout.buildDirectory.get()}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
         )
-
-        // property("sonar.sources", subprojects.joinToString(",") { "${it.projectDir}/src/main/kotlin" })
-        // property("sonar.tests", subprojects.joinToString(",") { "${it.projectDir}/src/test/kotlin" })
-        // property("sonar.java.binaries", subprojects.joinToString(",") { "${it.layout.buildDirectory.get()}/classes/kotlin/main" })
-        // property("sonar.java.test.binaries", subprojects.joinToString(",") { "${it.layout.buildDirectory.get()}/classes/kotlin/test" })
-
+        property("sonar.kotlin.coveragePlugin", "jacoco")
         property("sonar.kotlin.version", Versions.KOTLIN)
         property("sonar.exclusions", sonarGlobalExclusions.joinToString(","))
         property("sonar.cpd.exclusions", testExclusionPatterns.joinToString(","))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,16 +23,16 @@ allprojects {
 
 // 테스트하지 않는 코드 패턴 (JaCoCo + SonarQube 커버리지 + CPD 공통)
 val testExclusionPatterns = listOf(
-    "**/*Application*",
+    "**/*Application.kt",
     "**/config/**",
-    "**/*Config*",
+    "**/*Config.kt",
     "**/exception/**",
-    "**/*Exception*",
-    "**/*ErrorCode*/**",
+    "**/*Exception.kt",
+    "**/*ErrorCode.kt",
     "**/dto/**",
-    "**/*Request*",
-    "**/*Response*",
-    "**/*Entity*",
+    "**/*Request.kt",
+    "**/*Response.kt",
+    "**/*Entity.kt",
     "**/annotation/**",
     "**/generated/**"
 )
@@ -40,7 +40,6 @@ val testExclusionPatterns = listOf(
 // SonarQube 전체 분석 제외 패턴 (분석 자체가 의미 없는 파일들)
 val sonarGlobalExclusions = listOf(
     "**/build/**",
-    "**/generated/**",
 )
 
 subprojects {
@@ -173,8 +172,6 @@ configure<SonarExtension> {
         property("sonar.exclusions", sonarGlobalExclusions.joinToString(","))
         property("sonar.cpd.exclusions", testExclusionPatterns.joinToString(","))
         property("sonar.coverage.exclusions", testExclusionPatterns.joinToString(","))
-
-        property("sonar.test.inclusions", "**/*Test.kt:**/*Tests.kt:**/*Spec.kt")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,6 @@ tasks.register<JacocoReport>("jacocoRootReport") {
 
     dependsOn(subprojects.map { it.tasks.named("test") })
 
-    additionalSourceDirs.setFrom(subprojects.map { it.the<SourceSetContainer>()["main"].allSource.srcDirs })
     sourceDirectories.setFrom(subprojects.map { it.the<SourceSetContainer>()["main"].allSource.srcDirs })
     classDirectories.setFrom(subprojects.map { subproject ->
         subproject.fileTree(subproject.layout.buildDirectory.get().asFile.resolve("classes/kotlin/main")) {
@@ -152,7 +151,7 @@ sonar {
             "sonar.coverage.jacoco.xmlReportPaths",
             "${layout.buildDirectory.get()}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
         )
-        property("sonar.kotlin.coveragePlugin", "jacoco")
+        property("sonar.kotlin.coveragePlugin", Plugins.JACOCO)
         property("sonar.kotlin.version", Versions.KOTLIN)
         property("sonar.exclusions", sonarGlobalExclusions.joinToString(","))
         property("sonar.cpd.exclusions", testExclusionPatterns.joinToString(","))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,11 +105,10 @@ configure(subprojects) {
             html.required.set(true)
         }
 
-        classDirectories.setFrom(files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(testExclusionPatterns)
-            }
-        }))
+        val sourceSets = project.the<SourceSetContainer>()
+        classDirectories.setFrom(sourceSets.getByName("main").output.classesDirs.asFileTree.matching {
+            exclude(testExclusionPatterns)
+        })
 
         executionData.setFrom(fileTree(layout.buildDirectory) {
             include("jacoco/*.exec")
@@ -131,8 +130,8 @@ tasks.register<JacocoReport>("jacocoRootReport") {
 
     additionalSourceDirs.setFrom(subprojects.map { it.the<SourceSetContainer>()["main"].allSource.srcDirs })
     sourceDirectories.setFrom(subprojects.map { it.the<SourceSetContainer>()["main"].allSource.srcDirs })
-    classDirectories.setFrom(subprojects.map {
-        it.the<SourceSetContainer>()["main"].output.asFileTree.matching {
+    classDirectories.setFrom(subprojects.map { subproject ->
+        subproject.the<SourceSetContainer>()["main"].output.classesDirs.asFileTree.matching {
             exclude(testExclusionPatterns)
         }
     })

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,8 +104,7 @@ configure(subprojects) {
             html.required.set(true)
         }
 
-        val sourceSets = project.the<SourceSetContainer>()
-        classDirectories.setFrom(sourceSets.getByName("main").output.classesDirs.asFileTree.matching {
+        classDirectories.setFrom(fileTree(layout.buildDirectory.dir("classes/kotlin/main")) {
             exclude(testExclusionPatterns)
         })
 
@@ -130,7 +129,7 @@ tasks.register<JacocoReport>("jacocoRootReport") {
     additionalSourceDirs.setFrom(subprojects.map { it.the<SourceSetContainer>()["main"].allSource.srcDirs })
     sourceDirectories.setFrom(subprojects.map { it.the<SourceSetContainer>()["main"].allSource.srcDirs })
     classDirectories.setFrom(subprojects.map { subproject ->
-        subproject.the<SourceSetContainer>()["main"].output.classesDirs.asFileTree.matching {
+        subproject.fileTree(subproject.layout.buildDirectory.get().asFile.resolve("classes/kotlin/main")) {
             exclude(testExclusionPatterns)
         }
     })

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -3,6 +3,8 @@ object Plugins {
     const val SPRING_DEPENDENCY_MANAGEMENT = "io.spring.dependency-management"
     const val DETEKT = "io.gitlab.arturbosch.detekt"
     const val KOVER = "org.jetbrains.kotlinx.kover"
+    const val JACOCO = "jacoco"
+    const val SONAR_QUBE = "org.sonarqube"
 
     object Kotlin {
         const val ALLOPEN = "org.jetbrains.kotlin.plugin.allopen"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,5 +4,7 @@ object Versions {
     const val KOTLIN = "1.9.25"
     const val DETEKT = "1.23.1"
     const val KOVER = "0.9.1"
+    const val SONAR_QUBE = "6.2.0.5505"
+    const val JACOCO = "0.8.13"
     const val JAVA_VERSION = "21"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,7 +3,6 @@ object Versions {
     const val SPRING_DEPENDENCY_MANAGEMENT = "1.1.7"
     const val KOTLIN = "1.9.25"
     const val DETEKT = "1.23.1"
-    const val KOVER = "0.9.1"
     const val SONAR_QUBE = "6.2.0.5505"
     const val JACOCO = "0.8.13"
     const val JAVA_VERSION = "21"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "multi-module-test"
+rootProject.name = "reed"
 
 include(
     "admin",


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #28 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [ ] ✨ Feature (기능 추가)
- [ ] 🐞 Bugfix (버그 수정)
- [x] 🔧 Refactor (코드 리팩토링)
- [x] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->

### 🎯 개요
- 프로젝트의 안정성과 개발 생산성을 향상시키기 위해 Gradle 기반의 빌드 자동화 및 코드 품질 관리 시스템을 구축했습니다.
- 이제 PR을 통해 JaCoCo를 이용한 테스트 커버리지 측정, SonarCloud를 이용한 정적 코드 분석 및 품질 게이트 관리가 자동화됩니다.

### ✨ 주요 변경 사항
**0. kover 대신 JaCoCo 사용**
- Kover는 JetBrains에서 개발한 Kotlin 전용 코드 커버리지 도구로 잠재력은 있지만, Kover에 대한 참고 자료가 매우 부족했습니다.
- 따라서, 현재 시점에서는 JaCoCo를 선택하는 것이 더 실용적이라고 판단했습니다.
- 추후, Kover 관련 충분한 자료가 축적되면 JaCoCo에서 Kover로의 마이그레이션을 고려할 예정입니다.

**1. JaCoCo 테스트 커버리지 설정**
- 멀티모듈 환경에 맞춰 각 하위 모듈의 테스트 커버리지를 측정하도록 설정했습니다.
- 루트 프로젝트에서 모든 모듈의 커버리지를 취합하는 통합 리포트(jacocoRootReport)를 생성하여 프로젝트 전체의 커버리지를 한눈에 파악할 수 있습니다.
- testExclusionPatterns 변수를 통해 DTO, Entity 등 테스트가 불필요한 클래스를 커버리지 측정에서 일관되게 제외하여 리포트의 정확성을 높였습니다.

**2. SonarQube 정적 분석 연동**
- 생성된 JaCoCo 통합 리포트를 SonarCloud 분석에 활용하도록 연동했습니다.
- sonarGlobalExclusions 변수를 통해 빌드 결과물 등 분석이 무의미한 파일을 제외하여 분석 효율을 높였습니다.
- .yml, .properties 파일을 분석 대상에 포함하여, SonarCloud가 하드코딩된 API 키나 비밀번호 등 보안 비밀(Secrets)을 탐지할 수 있도록 했습니다.

**3. Gradle 빌드 스크립트 고도화**
- tasks.named, dependsOn("이름") 등 Gradle의 지연 설정(Lazy Configuration) 방식을 전면 적용하여 빌드 성능을 최적화하고 잠재적 오류를 방지했습니다.

**4. 편의 태스크 추가 및 정리**
- 개발 및 CI/CD 환경의 목적에 맞는 다양한 편의 태스크를 추가했습니다.
- fullCheck (CI/CD용): 테스트, 커버리지, SonarCloud 분석까지 전체 파이프라인을 한 번에 실행합니다.
- checkCoverage (로컬용): SonarCloud 분석 없이 로컬에서 빠르게 커버리지만 확인합니다.
- cleanReports (로컬용): 생성된 모든 리포트를 삭제합니다.

**5. CI 워크플로우 간소화 (GitHub Actions)**
- 기존에 여러 단계로 나뉘어 있던 Gradle 실행 명령을 새로 추가한 fullCheck 태스크 하나로 통합했습니다.
- 이를 통해 CI 스크립트의 가독성과 유지보수성을 크게 향상시켰습니다.

### 🚀 실행 방법
- 로컬에서 커버리지 확인: `./gradlew checkCoverage`
- 로컬에서 리포트 삭제 : `./gradlew cleanReports`
- CI: Pull Request 생성 시 GitHub Actions에서 `./gradlew fullCheck`가 자동으로 실행됩니다.


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |<img src="링크" width="300" />| 기능 설명 |<img src="링크" width="300" />|


## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- 실행 방법 부분에 대해서 민우님의 생각이 궁금합니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 코드 커버리지 및 정적 분석을 위한 JaCoCo와 SonarQube 통합이 추가되었습니다.
  * 모든 서브프로젝트에 대해 테스트, 커버리지 리포트, SonarQube 분석을 실행하는 편리한 Gradle 태스크가 도입되었습니다.
  * 코드 품질 및 커버리지 리포트 집계를 위한 집계 리포트 태스크가 추가되었습니다.

* **개선 사항**
  * CI 워크플로우에서 SonarCloud 패키지 캐싱 및 전체 코드 분석이 가능해졌습니다.
  * 프로젝트 이름이 "multi-module-test"에서 "reed"로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->