### PR TITLE
fix: sub 클레임 값을 UUID로 변환해 Authentication 객체의 principal로 설정하도록 수정

### DIFF
--- a/gateway/src/main/kotlin/org/yapp/gateway/security/SecurityConfig.kt
+++ b/gateway/src/main/kotlin/org/yapp/gateway/security/SecurityConfig.kt
@@ -5,7 +5,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.web.SecurityFilterChain
 
 /**
@@ -14,7 +16,7 @@ import org.springframework.security.web.SecurityFilterChain
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val jwtAuthenticationConverter: JwtAuthenticationConverter,
+    private val jwtAuthenticationConverter: Converter<Jwt, out AbstractAuthenticationToken>,
     private val customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
     private val customAccessDeniedHandler: CustomAccessDeniedHandler
 ) {


### PR DESCRIPTION

<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #43 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [ ] ✨ Feature (기능 추가)
- [x] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
### 변경 사항
- Spring Security의 Authentication 객체에 저장되는 Principal의 타입을 기존 String에서 UUID로 변경했습니다.

### 문제 상황
- 기존에는 JWT의 sub 클레임(String)이 그대로 Authentication 객체의 Principal로 사용되었습니다.
- 이로 인해 컨트롤러에서 @AuthenticationPrincipal userId: UUID로 받으려고 하면, Spring은 String 타입의 principal을 UUID 타입으로 자동 변환하려고 시도하는 과정에서 변환해 실패하게 되었습니다.
- 결국 null을 메서드 파라미터로 전달하게 되고 non-null 파라미터(userId: UUID)에 null이 전달되면서 NullPointerException이 발생했습니다.

### 해결 방법
- jwtAuthenticationConverter의 Bean의 구현을 변경했습니다.
- 기존의 setPrincipalClaimName()을 사용하는 대신, Converter<Jwt, AbstractAuthenticationToken>을 직접 구현했습니다.
- 새로운 컨버터는 JWT의 sub 클레임 값을 UUID.fromString()을 통해 UUID 객체로 변환합니다.
- 변환된 UUID 객체를 Principal로 사용하는 UsernamePasswordAuthenticationToken을 생성하여 반환하도록 수정했습니다.


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |<img src="링크" width="300" />| 기능 설명 |<img src="링크" width="300" />|


## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- ..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터링**
  * JWT 인증 변환 로직이 개선되어, 토큰에서 역할 정보를 보다 명확하게 추출하고 인증 처리가 더욱 안전하게 변경되었습니다.  
  * 사용자 정보가 UUID 형식으로 처리되어 인증 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->