### PR TITLE
Book 189 feature/#58

### DIFF
--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponse.kt
@@ -30,7 +30,16 @@ data class ReadingRecordResponse private constructor(
     val createdAt: String,
 
     @Schema(description = "수정 일시", example = "2023-01-01T12:00:00")
-    val updatedAt: String
+    val updatedAt: String,
+
+    @Schema(description = "도서 제목", example = "클린 코드")
+    val bookTitle: String?,
+
+    @Schema(description = "출판사", example = "인사이트")
+    val bookPublisher: String?,
+
+    @Schema(description = "도서 썸네일 URL", example = "https://example.com/book-cover.jpg")
+    val bookCoverImageUrl: String?
 ) {
     companion object {
         private val dateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
@@ -44,7 +53,10 @@ data class ReadingRecordResponse private constructor(
                 review = readingRecordInfoVO.review.value,
                 emotionTags = readingRecordInfoVO.emotionTags,
                 createdAt = readingRecordInfoVO.createdAt.format(dateTimeFormatter),
-                updatedAt = readingRecordInfoVO.updatedAt.format(dateTimeFormatter)
+                updatedAt = readingRecordInfoVO.updatedAt.format(dateTimeFormatter),
+                bookTitle = readingRecordInfoVO.bookTitle,
+                bookPublisher = readingRecordInfoVO.bookPublisher,
+                bookCoverImageUrl = readingRecordInfoVO.bookCoverImageUrl
             )
         }
     }

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecord/vo/ReadingRecordInfoVO.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecord/vo/ReadingRecordInfoVO.kt
@@ -11,7 +11,10 @@ data class ReadingRecordInfoVO private constructor(
     val review: ReadingRecord.Review,
     val emotionTags: List<String>,
     val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime
+    val updatedAt: LocalDateTime,
+    val bookTitle: String? = null,
+    val bookPublisher: String? = null,
+    val bookCoverImageUrl: String? = null
 ) {
     init {
         require(emotionTags.size <= 3) { "Maximum 3 emotion tags are allowed" }
@@ -23,7 +26,10 @@ data class ReadingRecordInfoVO private constructor(
     companion object {
         fun newInstance(
             readingRecord: ReadingRecord,
-            emotionTags: List<String>
+            emotionTags: List<String>,
+            bookTitle: String? = null,
+            bookPublisher: String? = null,
+            bookCoverImageUrl: String? = null
         ): ReadingRecordInfoVO {
             return ReadingRecordInfoVO(
                 id = readingRecord.id,
@@ -33,7 +39,10 @@ data class ReadingRecordInfoVO private constructor(
                 review = readingRecord.review,
                 emotionTags = emotionTags,
                 createdAt = readingRecord.createdAt ?: throw IllegalStateException("createdAt은 null일 수 없습니다."),
-                updatedAt = readingRecord.updatedAt ?: throw IllegalStateException("updatedAt은 null일 수 없습니다.")
+                updatedAt = readingRecord.updatedAt ?: throw IllegalStateException("updatedAt은 null일 수 없습니다."),
+                bookTitle = bookTitle,
+                bookPublisher = bookPublisher,
+                bookCoverImageUrl = bookCoverImageUrl
             )
         }
     }

--- a/domain/src/main/kotlin/org/yapp/domain/userbook/UserBookRepository.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/userbook/UserBookRepository.kt
@@ -10,6 +10,7 @@ interface UserBookRepository {
     fun findByUserIdAndBookIsbn(userId: UUID, isbn: String): UserBook?
     fun findByBookIdAndUserId(bookId: UUID, userId: UUID): UserBook?
     fun findByIdAndUserId(id: UUID, userId: UUID): UserBook?
+    fun findById(id: UUID): UserBook?
 
     fun save(userBook: UserBook): UserBook
 

--- a/infra/src/main/kotlin/org/yapp/infra/external/aladin/AladinApi.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/external/aladin/AladinApi.kt
@@ -22,7 +22,8 @@ class AladinApi(
 
     fun lookupBook(request: AladinBookLookupRequest): Result<AladinBookDetailResponse> {
         return runCatching {
-            val aladinApiParams = request.toMap()
+            val aladinApiParams = request.toMap().toMutableMap()
+            aladinApiParams["Cover"] = "Big"
             aladinRestClient.itemLookUp(ttbKey, aladinApiParams) // Map으로 전달
         }
     }

--- a/infra/src/main/kotlin/org/yapp/infra/userbook/repository/impl/UserBookRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/userbook/repository/impl/UserBookRepositoryImpl.kt
@@ -28,6 +28,10 @@ class UserBookRepositoryImpl(
         return jpaUserBookRepository.findByIdAndUserId(id, userId)?.toDomain()
     }
 
+    override fun findById(id: UUID): UserBook? {
+        return jpaUserBookRepository.findById(id).orElse(null)?.toDomain()
+    }
+
     override fun save(userBook: UserBook): UserBook {
         val savedEntity = jpaUserBookRepository.saveAndFlush(UserBookEntity.fromDomain(userBook))
         return savedEntity.toDomain()


### PR DESCRIPTION
<h2>🔗 관련 이슈</h2><p></p><ul><li><p>Close #58 </p></li></ul><p></p><h2>📘 작업 유형</h2><p></p><ul><li><p>[x] ✨ Feature (기능 추가)</p></li><li><p>[ ] 🐞 Bugfix (버그 수정)</p></li><li><p>[ ] 🔧 Refactor (코드 리팩토링)</p></li><li><p>[ ] ⚙️ Chore (환경 설정)</p></li><li><p>[ ] 📝 Docs (문서 작성 및 수정)</p></li><li><p>[ ] ✅ Test (기능 테스트)</p></li><li><p>[ ] 🎨 style (코드 스타일 수정)</p></li></ul><p></p><h2>📙 작업 내역</h2><p></p><ul><li><p>독서기록 생성 및 조회 API 응답에 관련 도서 정보를 포함하도록 기능을 추가했습니다.</p></li><li><p>응답에 추가된 정보는 <b>도서 제목, 출판사, 도서 표지 이미지 URL</b>입니다.</p></li><li><p><code>ReadingRecordDomainService</code>에서 독서기록을 처리할 때, <code>UserBookRepository</code>를 통해 연관된 <code>UserBook</code> 엔티티를 조회하고 해당 도서 정보를 <code>ReadingRecordInfoVO</code>에 담아 반환하도록 수정했습니다.</p></li><li><p>추가적으로, 알라딘 API에서 책 정보를 조회할 때 더 큰 사이즈의 표지 이미지를 가져오도록 요청 파라미터를 수정하여 이미지 품질을 개선했습니다.</p></li></ul><p></p><h2>🧪 테스트 내역</h2><p></p><ul><li><p>[x] 브라우저/기기에서 동작 확인</p></li><li><p>[x] 엣지 케이스 테스트 완료</p></li><li><p>[x] 기존 기능 영향 없음</p></li></ul><p></p><h2>🎨 스크린샷 또는 시연 영상 (선택)</h2><p></p><div class="horizontal-scroll-wrapper"><div class="table-block-component"><response-element class="" ng-version="0.0.0-PLACEHOLDER"><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!---->
기능 | 미리보기 | 기능 | 미리보기
-- | -- | -- | --
기능 설명 |   | 기능 설명 |  

</div><div _ngcontent-ng-c1880817486="" hide-from-message-actions="" class="table-footer hide-from-message-actions ng-star-inserted"><button _ngcontent-ng-c1880817486="" mat-button="" class="mdc-button mat-mdc-button-base mat-mdc-button mat-unthemed" mat-ripple-loader-uninitialized="" mat-ripple-loader-class-name="mat-mdc-button-ripple" jslog="184701;track:generic_click,impression;BardVeMetadataKey:[[&quot;r_d42ad97bb8db8ad9&quot;,&quot;c_9df103c3a468ee7f&quot;,null,null,null,null,null,null,1,null,null,null,0]]"><span class="mat-mdc-button-persistent-ripple mdc-button__ripple"></span><span class="mdc-button__label"><span _ngcontent-ng-c1880817486="" class="export-sheets-button"><span _ngcontent-ng-c1880817486="" class="export-sheets-icon"><mat-icon _ngcontent-ng-c1880817486="" role="img" fonticon="drive_spreadsheet" class="mat-icon notranslate google-symbols mat-ligature-font mat-icon-no-color" aria-hidden="true" data-mat-icon-type="font" data-mat-icon-name="drive_spreadsheet"></mat-icon></span><span _ngcontent-ng-c1880817486="">Sheets로 내보내기</span></span></span><span class="mat-focus-indicator"></span><span class="mat-mdc-button-touch-target"></span></button></div><!----></div></table-block><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----></response-element></div></div><p></p><h2>✅ PR 체크리스트</h2><p></p><ul><li><p>[x] 커밋 메시지가 명확합니다</p></li><li><p>[x] PR 제목이 컨벤션에 맞습니다</p></li><li><p>[ ] 관련 이슈 번호를 작성했습니다</p></li><li><p>[x] 기능이 정상적으로 작동합니다</p></li><li><p>[x] 불필요한 코드를 제거했습니다</p></li></ul><p></p><h2>💬 추가 설명 or 리뷰 포인트 (선택)</h2><p></p><ul><li><p>독서기록 목록 조회 시, N+1 문제를 방지하기 위해 개별 독서기록마다 <code>UserBook</code>을 조회하지 않습니다.</p></li><li><p>대신, 해당 페이지의 모든 독서기록이 동일한 <code>userBookId</code>에 속하므로, <code>UserBook</code>을 <b>한 번만 조회</b>하여 모든 응답 DTO에 동일한 책 정보를 매핑해주었습니다.</p></li><li><p>이 방식은 현재 요구사항에 효율적이며, 추후 여러 책의 독서기록을 한 번에 조회하는 기능이 생긴다면 추가적인 최적화가 필요할 수 있습니다.</p></li></ul>