### PR TITLE
feat: 알라딘 도서 검색 ISBN 변환 및 유효성 검증 로직 개선

### DIFF
--- a/apis/src/main/kotlin/org/yapp/apis/auth/util/IsbnConverter.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/auth/util/IsbnConverter.kt
@@ -11,13 +11,8 @@ object IsbnConverter {
 
     fun toIsbn13(isbn10: String?): String? {
         val sanitized = isbn10?.replace("-", "")?.uppercase()
-
-        if (sanitized.isNullOrBlank() || sanitized.length != ISBN10_LENGTH) {
-            return null
-        }
-        if (!sanitized.matches(Regex(RegexUtils.ISBN10_PATTERN))) {
-            return null
-        }
+            ?.takeIf { it.length == ISBN10_LENGTH && it.matches(Regex(RegexUtils.ISBN10_PATTERN)) }
+            ?: return null
 
         val stem = ISBN13_PREFIX + sanitized.substring(0, ISBN10_LENGTH - 1)
 

--- a/apis/src/main/kotlin/org/yapp/apis/book/dto/response/BookDetailResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/dto/response/BookDetailResponse.kt
@@ -26,10 +26,14 @@ data class BookDetailResponse private constructor(
 
     companion object {
         private const val DEFAULT_MAX_PAGE_COUNT = 4032
-        
+
         fun from(response: AladinBookDetailResponse, userBookStatus: BookStatus = BookStatus.BEFORE_REGISTRATION): BookDetailResponse {
             val item = response.item.firstOrNull()
                 ?: throw IllegalArgumentException("No book item found in detail response.")
+
+            val isbn13 = item.isbn13?.takeIf { it.isNotBlank() }
+                ?: IsbnConverter.toIsbn13(item.isbn?.takeIf { it.isNotBlank() })
+                ?: throw IllegalArgumentException("Either isbn13 or isbn must be provided")
 
             return BookDetailResponse(
                 version = response.version,
@@ -39,7 +43,7 @@ data class BookDetailResponse private constructor(
                 pubDate = item.pubDate ?: "",
                 description = item.description ?: "",
                 mallType = item.mallType,
-                isbn13 = item.isbn13 ?: IsbnConverter.toIsbn13(item.isbn) ?: throw IllegalArgumentException("Either isbn13 or isbn must be provided"),
+                isbn13 = isbn13,
                 coverImageUrl = item.cover,
                 categoryName = item.categoryName,
                 publisher = item.publisher ?: "",

--- a/apis/src/main/kotlin/org/yapp/apis/book/service/AladinBookQueryService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/service/AladinBookQueryService.kt
@@ -10,6 +10,8 @@ import org.yapp.apis.book.dto.response.BookDetailResponse
 import org.yapp.apis.book.dto.response.BookSearchResponse
 import org.yapp.apis.book.exception.BookErrorCode
 import org.yapp.apis.book.exception.BookException
+import org.yapp.apis.util.IsbnConverter
+import org.yapp.globalutils.validator.IsbnValidator
 import org.yapp.infra.external.aladin.AladinApi
 import org.yapp.infra.external.aladin.request.AladinBookLookupRequest
 import org.yapp.infra.external.aladin.request.AladinBookSearchRequest
@@ -42,7 +44,29 @@ class AladinBookQueryService(
                 log.error("Failed to call Aladin search API for request: '$request'", exception)
                 throw BookException(BookErrorCode.ALADIN_API_SEARCH_FAILED, exception.message)
             }
-        return BookSearchResponse.from(response)
+
+        val filteredItems = response.item.filter { item ->
+            val isbn13 = item.isbn13?.takeIf { it.isNotBlank() } 
+                ?: item.isbn?.let { IsbnConverter.toIsbn13(it) }
+            
+            isbn13?.let { IsbnValidator.isValidIsbn(it) } ?: false
+        }
+
+        val filteredResponse = AladinSearchResponse(
+            version = response.version,
+            title = response.title,
+            link = response.link,
+            pubDate = response.pubDate,
+            totalResults = filteredItems.size,
+            startIndex = response.startIndex,
+            itemsPerPage = response.itemsPerPage,
+            query = response.query,
+            searchCategoryId = response.searchCategoryId,
+            searchCategoryName = response.searchCategoryName,
+            item = filteredItems
+        )
+
+        return BookSearchResponse.from(filteredResponse)
     }
 
     override fun getBookDetail(@Valid request: BookDetailRequest): BookDetailResponse {

--- a/global-utils/src/main/kotlin/org/yapp/globalutils/validator/IsbnValidator.kt
+++ b/global-utils/src/main/kotlin/org/yapp/globalutils/validator/IsbnValidator.kt
@@ -1,9 +1,12 @@
 package org.yapp.globalutils.validator
 
+import org.yapp.globalutils.util.RegexUtils
+
 object IsbnValidator {
-    private val ISBN_REGEX = Regex("^(.{10}|.{13})$")
+    private val ISBN10_REGEX = Regex(RegexUtils.ISBN10_PATTERN)
+    private val ISBN13_REGEX = Regex(RegexUtils.ISBN13_PATTERN)
 
     fun isValidIsbn(isbn: String): Boolean {
-        return isbn.matches(ISBN_REGEX)
+        return isbn.matches(ISBN10_REGEX) || isbn.matches(ISBN13_REGEX)
     }
 }

--- a/infra/src/main/kotlin/org/yapp/infra/external/aladin/response/AladinSearchResponse.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/external/aladin/response/AladinSearchResponse.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.math.BigDecimal
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class AladinSearchResponse internal constructor(
+data class AladinSearchResponse(
     @JsonProperty("version") val version: String?,
     @JsonProperty("title") val title: String?,
     @JsonProperty("link") val link: String?,
@@ -20,7 +20,7 @@ data class AladinSearchResponse internal constructor(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class AladinSearchItem internal constructor(
+data class AladinSearchItem(
     @JsonProperty("title") val title: String,
     @JsonProperty("link") val link: String,
     @JsonProperty("author") val author: String?,


### PR DESCRIPTION
## 🔗 관련 이슈  
- Close #75 

## 📘 작업 유형  
- [x] ✨ Feature (기능 추가)  
- [x] 🐞 Bugfix (버그 수정)  
- [ ] 🔧 Refactor (코드 리팩토링)  
- [ ] ⚙️ Chore (환경 설정)  
- [ ] 📝 Docs (문서 작성 및 수정)  
- [ ] ✅ Test (기능 테스트)  
- [ ] 🎨 style (코드 스타일 수정)  

## 📙 작업 내역  
- ISBN10 → ISBN13 변환 로직 개선 (`toIsbn13`)
- `BookDetailResponse`, `BookSearchResponse` 내 ISBN 처리 로직 정리 및 예외 방어 처리 추가
- `BookSearchResponse` 변환 시 유효한 ISBN만 필터링
- `IsbnValidator` 유틸 클래스 도입하여 유효성 검사 적용
- 알라딘 검색 API 결과에 ISBN 필터링 적용

## 🧪 테스트 내역  
- [x] 브라우저/기기에서 동작 확인  
- [x] 엣지 케이스 테스트 완료 (예: ISBN 누락, 잘못된 포맷)  
- [x] 기존 기능 영향 없음  

## 🎨 스크린샷 또는 시연 영상 (선택)  
| 기능 설명 | 미리보기 |
|:--:|:--:|
| (예: 검색 필터링 전/후) | <img src="링크" width="300" /> |

## ✅ PR 체크리스트  
- [x] 커밋 메시지가 명확합니다  
- [x] PR 제목이 컨벤션에 맞습니다  
- [x] 관련 이슈 번호를 작성했습니다  
- [x] 기능이 정상적으로 작동합니다  
- [x] 불필요한 코드를 제거했습니다  

## 💬 추가 설명 or 리뷰 포인트  
- `isbn13`이 존재하지 않으면 `isbn10`을 변환하여 사용합니다.  
- 유효하지 않은 ISBN은 리스트에서 제외되며, `BookSummary`가 `null`인 경우도 필터링됩니다.  
- 리뷰 시 **ISBN 변환 및 유효성 검증 로직**이 안정적인지 확인 부탁드립니다.
