### PR TITLE
refactor: 알라딘 외부 검색 API 호출 시 totalResult를 200개로 제한, lastPage 컬럼 값 추가

### DIFF
--- a/apis/src/main/kotlin/org/yapp/apis/book/dto/response/BookSearchResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/dto/response/BookSearchResponse.kt
@@ -19,12 +19,6 @@ data class BookSearchResponse private constructor(
     @field:Schema(description = "검색 결과 제목", example = "데미안")
     val title: String?,
 
-    @field:Schema(
-        description = "검색 결과 링크",
-        example = "http://www.aladin.co.kr/shop/wsarch.aspx?SearchTarget=Book&query=%EC%95%84%EB%B0%94%EC%9D%98+%ED%95%B4%EB%B0%A9%EC%9D%BC%EC%A7%80&partner=openAPI"
-    )
-    val link: String?,
-
     @field:Schema(description = "출간일", example = "2025-07-30")
     val pubDate: String?,
 
@@ -57,11 +51,10 @@ data class BookSearchResponse private constructor(
     }
 
     companion object {
-        fun from(response: AladinSearchResponse): BookSearchResponse {
+        fun of(response: AladinSearchResponse, isLastPage: Boolean): BookSearchResponse { // Added isLastPage parameter
             return BookSearchResponse(
                 version = response.version,
                 title = response.title,
-                link = response.link,
                 pubDate = response.pubDate,
                 totalResults = response.totalResults,
                 startIndex = response.startIndex,
@@ -69,7 +62,7 @@ data class BookSearchResponse private constructor(
                 query = response.query,
                 searchCategoryId = response.searchCategoryId,
                 searchCategoryName = response.searchCategoryName,
-                lastPage = response.lastPage,
+                lastPage = isLastPage,
                 books = response.item.map {
                     BookSummary.of(
                         isbn = it.isbn,
@@ -77,7 +70,8 @@ data class BookSearchResponse private constructor(
                         title = it.title,
                         author = AuthorExtractor.extractAuthors(it.author),
                         publisher = it.publisher,
-                        coverImageUrl = it.cover
+                        coverImageUrl = it.cover,
+                        link = it.link
                     )
                 }
             )
@@ -105,6 +99,12 @@ data class BookSearchResponse private constructor(
         )
         val coverImageUrl: String,
 
+        @field:Schema(
+            description = "알라딘 도서 상세 페이지 링크",
+            example = "http://www.aladin.co.kr/shop/wproduct.aspx?ItemId=3680175"
+        )
+        val link: String, // Added link field
+
         @field:Schema(description = "사용자의 책 상태", example = "BEFORE_REGISTRATION")
         val userBookStatus: BookStatus
     ) {
@@ -119,7 +119,8 @@ data class BookSearchResponse private constructor(
                 title: String?,
                 author: String?,
                 publisher: String?,
-                coverImageUrl: String
+                coverImageUrl: String,
+                link: String // Added link
             ): BookSummary {
                 require(!title.isNullOrBlank()) { "Title is required" }
 
@@ -130,6 +131,7 @@ data class BookSearchResponse private constructor(
                     author = author,
                     publisher = publisher?.let { BookDataValidator.removeParenthesesFromPublisher(it) },
                     coverImageUrl = coverImageUrl,
+                    link = link,
                     userBookStatus = BookStatus.BEFORE_REGISTRATION
                 )
             }

--- a/apis/src/main/kotlin/org/yapp/apis/book/dto/response/BookSearchResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/dto/response/BookSearchResponse.kt
@@ -46,6 +46,9 @@ data class BookSearchResponse private constructor(
     @field:Schema(description = "검색 카테고리 이름", example = "소설/시/희곡")
     val searchCategoryName: String?,
 
+    @field:Schema(description = "마지막 페이지 여부", example = "false")
+    val lastPage: Boolean,
+
     @field:Schema(description = "검색된 책 목록")
     val books: List<BookSummary>
 ) {
@@ -66,6 +69,7 @@ data class BookSearchResponse private constructor(
                 query = response.query,
                 searchCategoryId = response.searchCategoryId,
                 searchCategoryName = response.searchCategoryName,
+                lastPage = response.lastPage,
                 books = response.item.map {
                     BookSummary.of(
                         isbn = it.isbn,

--- a/apis/src/main/kotlin/org/yapp/apis/book/exception/BookErrorCode.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/exception/BookErrorCode.kt
@@ -11,7 +11,8 @@ enum class BookErrorCode(
 
     /* 500 INTERNAL_SERVER_ERROR */
     ALADIN_API_SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BOOK_500_01", "알라딘 도서 검색 API 호출에 실패했습니다."),
-    ALADIN_API_LOOKUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BOOK_500_02", "알라딘 도서 상세 조회 API 호출에 실패했습니다.");
+    ALADIN_API_LOOKUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BOOK_500_02", "알라딘 도서 상세 조회 API 호출에 실패했습니다."),
+    ALADIN_API_RESULT_LIMIT(HttpStatus.INTERNAL_SERVER_ERROR, "BOOK_500_03", "검색 결과가 200개를 초과하여 모든 결과를 조회했습니다.");
 
     override fun getHttpStatus(): HttpStatus = httpStatus
     override fun getCode(): String = code

--- a/apis/src/main/kotlin/org/yapp/apis/book/exception/BookErrorCode.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/exception/BookErrorCode.kt
@@ -9,10 +9,10 @@ enum class BookErrorCode(
     private val message: String
 ) : BaseErrorCode {
 
-    /* 500 INTERNAL_SERVER_ERROR */
-    ALADIN_API_SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BOOK_500_01", "알라딘 도서 검색 API 호출에 실패했습니다."),
-    ALADIN_API_LOOKUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BOOK_500_02", "알라딘 도서 상세 조회 API 호출에 실패했습니다."),
-    ALADIN_API_RESULT_LIMIT(HttpStatus.INTERNAL_SERVER_ERROR, "BOOK_500_03", "검색 결과가 200개를 초과하여 모든 결과를 조회했습니다.");
+    /* 403 FORBIDDEN */
+    ALADIN_API_SEARCH_FAILED(HttpStatus.FORBIDDEN, "BOOK_403_01", "알라딘 도서 검색 API 호출에 실패했습니다."),
+    ALADIN_API_LOOKUP_FAILED(HttpStatus.FORBIDDEN, "BOOK_403_02", "알라딘 도서 상세 조회 API 호출에 실패했습니다."),
+    ALADIN_API_RESULT_LIMIT(HttpStatus.FORBIDDEN, "BOOK_403_03", "검색 결과가 200개를 초과하여 모든 결과를 조회했습니다.");
 
     override fun getHttpStatus(): HttpStatus = httpStatus
     override fun getCode(): String = code

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordController.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequest
+import org.yapp.apis.readingrecord.dto.response.ReadingRecordPageResponse // Added import
 import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponse
 import org.yapp.apis.readingrecord.usecase.ReadingRecordUseCase
 import org.yapp.domain.readingrecord.ReadingRecordSortType
@@ -61,7 +62,7 @@ class ReadingRecordController(
         @RequestParam(required = false) sort: ReadingRecordSortType?,
         @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
         pageable: Pageable
-    ): ResponseEntity<Page<ReadingRecordResponse>> {
+    ): ResponseEntity<ReadingRecordPageResponse> {
         val response = readingRecordUseCase.getReadingRecordsByUserBookId(
             userId = userId,
             userBookId = userBookId,

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApi.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApi.kt
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequest
+import org.yapp.apis.readingrecord.dto.response.ReadingRecordPageResponse
 import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponse
 import org.yapp.apis.readingrecord.dto.response.SeedStatsResponse
 import org.yapp.domain.readingrecord.ReadingRecordSortType
@@ -105,7 +106,7 @@ interface ReadingRecordControllerApi {
         @RequestParam(required = false) @Parameter(description = "정렬 방식 (PAGE_NUMBER_ASC, PAGE_NUMBER_DESC, CREATED_DATE_ASC, CREATED_DATE_DESC)") sort: ReadingRecordSortType?,
         @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
         @Parameter(description = "페이지네이션 정보 (페이지 번호, 페이지 크기, 정렬 방식)") pageable: Pageable
-    ): ResponseEntity<Page<ReadingRecordResponse>>
+    ): ResponseEntity<ReadingRecordPageResponse>
 
     @Operation(
         summary = "씨앗 통계 조회",

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordPageResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordPageResponse.kt
@@ -1,0 +1,37 @@
+package org.yapp.apis.readingrecord.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
+
+@Schema(
+    name = "ReadingRecordPageResponse",
+    description = "독서 기록 페이징 조회 응답"
+)
+data class ReadingRecordPageResponse private constructor(
+    @field:Schema(description = "마지막 페이지 여부", example = "false")
+    val lastPage: Boolean,
+
+    @field:Schema(description = "총 결과 개수", example = "42")
+    val totalResults: Int,
+
+    @field:Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+    val startIndex: Int,
+
+    @field:Schema(description = "한 페이지당 아이템 개수", example = "10")
+    val itemsPerPage: Int,
+
+    @field:Schema(description = "독서 기록 목록")
+    val readingRecords: List<ReadingRecordResponse>
+) {
+    companion object {
+        fun from(page: Page<ReadingRecordResponse>): ReadingRecordPageResponse {
+            return ReadingRecordPageResponse(
+                lastPage = page.isLast,
+                totalResults = page.totalElements.toInt(),
+                startIndex = page.number,
+                itemsPerPage = page.size,
+                readingRecords = page.content
+            )
+        }
+    }
+}

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCase.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCase.kt
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.transaction.annotation.Transactional
 import org.yapp.apis.book.service.UserBookService
 import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequest
+import org.yapp.apis.readingrecord.dto.response.ReadingRecordPageResponse // Added import
 import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponse
 import org.yapp.apis.readingrecord.dto.response.SeedStatsResponse
 import org.yapp.apis.readingrecord.service.ReadingRecordService
@@ -55,15 +56,16 @@ class ReadingRecordUseCase(
         userBookId: UUID,
         sort: ReadingRecordSortType?,
         pageable: Pageable
-    ): Page<ReadingRecordResponse> {
+    ): ReadingRecordPageResponse {
         userService.validateUserExists(userId)
         userBookService.validateUserBookExists(userBookId, userId)
 
-        return readingRecordService.getReadingRecordsByDynamicCondition(
+        val page = readingRecordService.getReadingRecordsByDynamicCondition( // Stored in a variable
             userBookId = userBookId,
             sort = sort,
             pageable = pageable
         )
+        return ReadingRecordPageResponse.from(page) // Converted to new DTO
     }
 
     fun getSeedStats(

--- a/infra/src/main/kotlin/org/yapp/infra/external/aladin/response/AladinSearchResponse.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/external/aladin/response/AladinSearchResponse.kt
@@ -16,8 +16,7 @@ data class AladinSearchResponse(
     @JsonProperty("query") val query: String? = null,
     @JsonProperty("searchCategoryId") val searchCategoryId: Int? = null,
     @JsonProperty("searchCategoryName") val searchCategoryName: String? = null,
-    @JsonProperty("item") val item: List<AladinSearchItem> = emptyList(),
-    var lastPage: Boolean = false
+    @JsonProperty("item") val item: List<AladinSearchItem> = emptyList()
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/infra/src/main/kotlin/org/yapp/infra/external/aladin/response/AladinSearchResponse.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/external/aladin/response/AladinSearchResponse.kt
@@ -16,7 +16,8 @@ data class AladinSearchResponse(
     @JsonProperty("query") val query: String? = null,
     @JsonProperty("searchCategoryId") val searchCategoryId: Int? = null,
     @JsonProperty("searchCategoryName") val searchCategoryName: String? = null,
-    @JsonProperty("item") val item: List<AladinSearchItem> = emptyList()
+    @JsonProperty("item") val item: List<AladinSearchItem> = emptyList(),
+    var lastPage: Boolean = false
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #88 

## 📘 작업 유형
- [x] ✨ Feature (기능 추가)
- [x] 🐞 Bugfix (버그 수정)

## 📙 작업 내역
### 1. 알라딘 API 200개 제한 처리 로직 추가
- `(request.start ?: 1) * (response.itemsPerPage ?: 0)` 계산 결과가 200을 초과하는 경우 `BookException` 발생
- `BookErrorCode`에 `ALADIN_API_RESULT_LIMIT` 코드 추가  
  - 메시지: "검색 결과가 200개를 초과하여 모든 결과를 조회했습니다."
- `lastPage` 여부를 계산하여 `AladinSearchResponse`에 포함

### 2. `ReadingRecordController` 페이징 응답 개선
- 기존 `Page<ReadingRecordResponse>` 반환 구조를 `ReadingRecordPageResponse` DTO로 변경
- DTO에는 다음 필드 포함:
  - `lastPage` (마지막 페이지 여부)
  - `totalResults` (총 결과 개수)
  - `startIndex` (현재 페이지 번호)
  - `itemsPerPage` (페이지당 아이템 수)
  - `readingRecords` (독서 기록 목록)

### 3. `ReadingRecordUseCase` 수정
- `Page` 객체를 직접 반환하지 않고, `ReadingRecordPageResponse.from()` 메서드를 통해 변환 후 반환

### 4. `AladinSearchResponse` 수정
- `lastPage` 필드 추가 (마지막 페이지 여부 응답에 포함)

## 🧪 테스트 내역
- [x] 알라딘 API 호출 시 200개 초과 요청 차단 여부 확인
- [x] `ReadingRecordController` 응답 구조 변경 후 API 정상 응답 여부 확인
- [x] 마지막 페이지 여부(`lastPage`) 값 검증 완료
- [x] 기존 기능 영향 없음 확인

## 🎨 스크린샷
(해당 사항 없음)

## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 독서 기록 조회 시 페이지네이션 정보를 포함한 새로운 응답 형식이 도입되었습니다. 각 페이지가 마지막 페이지인지, 전체 결과 수, 시작 인덱스, 페이지당 항목 수 등 추가 정보를 확인할 수 있습니다.
  * 도서 검색 결과에 각 도서의 링크 정보가 추가되었습니다.

* **버그 수정**
  * 도서 검색 시 최대 200개의 결과만 조회할 수 있도록 제한이 적용되었습니다. 초과 시 안내 메시지가 제공됩니다.

* **변경 사항**
  * 독서 기록 조회 API의 응답 구조가 변경되어, 기존 페이지 객체 대신 새로운 페이지 응답 형식이 반환됩니다.
  * 일부 도서 API 오류 코드의 HTTP 상태 코드가 500에서 403으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->