### PR TITLE
feat: 내서제 도서 삭제 기능을 개발합니다.

### DIFF
--- a/apis/src/main/kotlin/org/yapp/apis/book/controller/BookController.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/controller/BookController.kt
@@ -6,8 +6,10 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -69,6 +71,15 @@ class BookController(
     ): ResponseEntity<UserBookPageResponse> {
         val response = bookUseCase.getUserLibraryBooks(userId, status, sort, title, pageable)
         return ResponseEntity.ok(response)
+    }
+
+    @DeleteMapping("/my-library/{userBookId}")
+    override fun deleteBookFromMyLibrary(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable userBookId: UUID,
+    ): ResponseEntity<Unit> {
+        bookUseCase.deleteBookFromMyLibrary(userId, userBookId)
+        return ResponseEntity.noContent().build()
     }
 
 }

--- a/apis/src/main/kotlin/org/yapp/apis/book/controller/BookControllerApi.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/controller/BookControllerApi.kt
@@ -141,4 +141,24 @@ interface BookControllerApi {
         @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
         pageable: Pageable
     ): ResponseEntity<UserBookPageResponse>
+
+    @Operation(summary = "내 서재에 저장한 도서 삭제", description = "내 서재에 저장한 도서를 삭제합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "성공적으로 도서를 삭제했습니다."
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "해당하는 도서를 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @DeleteMapping("/my-library/{userBookId}")
+    fun deleteBookFromMyLibrary(
+        @AuthenticationPrincipal userId: UUID,
+        @Parameter(description = "삭제할 도서 ID") @PathVariable userBookId: UUID
+    ): ResponseEntity<Unit>
 }

--- a/apis/src/main/kotlin/org/yapp/apis/book/service/UserBookService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/service/UserBookService.kt
@@ -83,4 +83,9 @@ class UserBookService(
             completedCount = userBookStatusCountsVO.completedCount
         )
     }
+
+    fun deleteUserBook(userBookId: UUID, userId: UUID) {
+        validateUserBookExists(userBookId, userId)
+        userBookDomainService.deleteById(userBookId)
+    }
 }

--- a/apis/src/main/kotlin/org/yapp/apis/book/usecase/BookUseCase.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/usecase/BookUseCase.kt
@@ -13,6 +13,7 @@ import org.yapp.apis.book.dto.response.UserBookResponse
 import org.yapp.apis.book.service.BookManagementService
 import org.yapp.apis.book.service.BookQueryService
 import org.yapp.apis.book.service.UserBookService
+import org.yapp.apis.readingrecord.service.ReadingRecordService
 import org.yapp.apis.user.service.UserService
 import org.yapp.domain.userbook.BookStatus
 import org.yapp.domain.userbook.UserBookSortType
@@ -26,7 +27,8 @@ class BookUseCase(
     private val bookQueryService: BookQueryService,
     private val userService: UserService,
     private val userBookService: UserBookService,
-    private val bookManagementService: BookManagementService
+    private val bookManagementService: BookManagementService,
+    private val readingRecordService: ReadingRecordService
 ) {
     fun searchBooks(
         request: BookSearchRequest,
@@ -94,6 +96,7 @@ class BookUseCase(
     ) {
         userService.validateUserExists(userId)
         userBookService.deleteUserBook(userBookId, userId)
+        readingRecordService.deleteAllByUserBookId(userBookId)
     }
 
     private fun mergeWithUserBookStatus(

--- a/apis/src/main/kotlin/org/yapp/apis/book/usecase/BookUseCase.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/usecase/BookUseCase.kt
@@ -87,6 +87,15 @@ class BookUseCase(
         return userBookService.findUserBooksByDynamicConditionWithStatusCounts(userId, status, sort, title, pageable)
     }
 
+    @Transactional
+    fun deleteBookFromMyLibrary(
+        userId: UUID,
+        userBookId: UUID
+    ) {
+        userService.validateUserExists(userId)
+        userBookService.deleteUserBook(userBookId, userId)
+    }
+
     private fun mergeWithUserBookStatus(
         searchedBooks: List<BookSummary>,
         userId: UUID

--- a/apis/src/main/kotlin/org/yapp/apis/book/usecase/BookUseCase.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/usecase/BookUseCase.kt
@@ -92,8 +92,8 @@ class BookUseCase(
         userBookId: UUID
     ) {
         userService.validateUserExists(userId)
-        userBookService.deleteUserBook(userBookId, userId)
         readingRecordService.deleteAllByUserBookId(userBookId)
+        userBookService.deleteUserBook(userBookId, userId)
     }
 
     private fun mergeWithUserBookStatus(

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordService.kt
@@ -45,4 +45,8 @@ class ReadingRecordService(
         val page = readingRecordDomainService.findReadingRecordsByDynamicCondition(userBookId, sort, pageable)
         return page.map { ReadingRecordResponse.from(it) }
     }
+
+    fun deleteAllByUserBookId(userBookId: UUID) {
+        readingRecordDomainService.deleteAllByUserBookId(userBookId)
+    }
 }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCase.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCase.kt
@@ -1,6 +1,5 @@
 package org.yapp.apis.readingrecord.usecase
 
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.transaction.annotation.Transactional
 import org.yapp.apis.book.service.UserBookService

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecordDomainService.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecordDomainService.kt
@@ -122,4 +122,7 @@ class ReadingRecordDomainService(
         }
     }
 
+    fun deleteAllByUserBookId(userBookId: UUID) {
+        readingRecordRepository.deleteAllByUserBookId(userBookId)
+    }
 }

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecordRepository.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecordRepository.kt
@@ -9,6 +9,7 @@ interface ReadingRecordRepository {
 
     fun save(readingRecord: ReadingRecord): ReadingRecord
 
+    fun deleteAllByUserBookId(userBookId: UUID)
 
     fun findById(id: UUID): ReadingRecord?
 

--- a/domain/src/main/kotlin/org/yapp/domain/userbook/UserBookDomainService.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/userbook/UserBookDomainService.kt
@@ -12,7 +12,6 @@ import java.util.*
 @DomainService
 class UserBookDomainService(
     private val userBookRepository: UserBookRepository,
-    private val readingRecordRepository: ReadingRecordRepository
 ) {
     fun upsertUserBook(
         userId: UUID,
@@ -80,7 +79,6 @@ class UserBookDomainService(
     }
 
     fun deleteById(userBookId: UUID) {
-        readingRecordRepository.deleteAllByUserBookId(userBookId)
         userBookRepository.deleteById(userBookId)
     }
 
@@ -110,7 +108,8 @@ class UserBookDomainService(
         return userBooks.map { userBook ->
             HomeBookVO.newInstance(
                 userBook = userBook,
-                lastRecordedAt = userBook.updatedAt ?: throw IllegalStateException("UserBook의 updatedAt이 null입니다: ${userBook.id}"),
+                lastRecordedAt = userBook.updatedAt
+                    ?: throw IllegalStateException("UserBook의 updatedAt이 null입니다: ${userBook.id}"),
                 recordCount = 0
             )
         }

--- a/domain/src/main/kotlin/org/yapp/domain/userbook/UserBookDomainService.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/userbook/UserBookDomainService.kt
@@ -6,11 +6,13 @@ import org.yapp.domain.userbook.vo.HomeBookVO
 import org.yapp.domain.userbook.vo.UserBookInfoVO
 import org.yapp.domain.userbook.vo.UserBookStatusCountsVO
 import org.yapp.globalutils.annotation.DomainService
+import org.yapp.domain.readingrecord.ReadingRecordRepository
 import java.util.*
 
 @DomainService
 class UserBookDomainService(
-    private val userBookRepository: UserBookRepository
+    private val userBookRepository: UserBookRepository,
+    private val readingRecordRepository: ReadingRecordRepository
 ) {
     fun upsertUserBook(
         userId: UUID,
@@ -75,6 +77,11 @@ class UserBookDomainService(
 
     fun existsByUserBookIdAndUserId(userBookId: UUID, userId: UUID): Boolean {
         return userBookRepository.existsByIdAndUserId(userBookId, userId)
+    }
+
+    fun deleteById(userBookId: UUID) {
+        readingRecordRepository.deleteAllByUserBookId(userBookId)
+        userBookRepository.deleteById(userBookId)
     }
 
     fun findBooksWithRecordsOrderByLatest(userId: UUID): List<HomeBookVO> {

--- a/domain/src/main/kotlin/org/yapp/domain/userbook/UserBookRepository.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/userbook/UserBookRepository.kt
@@ -12,6 +12,7 @@ interface UserBookRepository {
     fun existsByIdAndUserId(id: UUID, userId: UUID): Boolean
     fun findById(id: UUID): UserBook?
     fun save(userBook: UserBook): UserBook
+    fun deleteById(id: UUID)
     fun findAllByUserId(userId: UUID): List<UserBook>
     fun findAllByUserIdAndBookIsbn13In(userId: UUID, bookIsbn13s: List<String>): List<UserBook>
     fun findUserBooksByDynamicCondition(

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecord/repository/JpaReadingRecordRepository.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecord/repository/JpaReadingRecordRepository.kt
@@ -11,6 +11,8 @@ interface JpaReadingRecordRepository : JpaRepository<ReadingRecordEntity, UUID>,
 
     fun findAllByUserBookId(userBookId: UUID): List<ReadingRecordEntity>
 
+    fun deleteAllByUserBookId(userBookId: UUID)
+
     fun findAllByUserBookId(userBookId: UUID, pageable: Pageable): Page<ReadingRecordEntity>
 
     fun findAllByUserBookIdIn(userBookIds: List<UUID>): List<ReadingRecordEntity>

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecord/repository/impl/ReadingRecordRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecord/repository/impl/ReadingRecordRepositoryImpl.kt
@@ -21,6 +21,10 @@ class ReadingRecordRepositoryImpl(
         return savedEntity.toDomain()
     }
 
+    override fun deleteAllByUserBookId(userBookId: UUID) {
+        jpaReadingRecordRepository.deleteAllByUserBookId(userBookId)
+    }
+
     override fun findById(id: UUID): ReadingRecord? {
         return jpaReadingRecordRepository.findByIdOrNull(id)?.toDomain()
     }

--- a/infra/src/main/kotlin/org/yapp/infra/userbook/repository/impl/UserBookRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/userbook/repository/impl/UserBookRepositoryImpl.kt
@@ -38,6 +38,10 @@ class UserBookRepositoryImpl(
         return savedEntity.toDomain()
     }
 
+    override fun deleteById(id: UUID) {
+        jpaUserBookRepository.deleteById(id)
+    }
+
     override fun findAllByUserId(userId: UUID): List<UserBook> {
         return jpaUserBookRepository.findAllByUserId(userId).map { it.toDomain() }
     }


### PR DESCRIPTION
<!--
PR 제목 작성 가이드:
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
- Close #92 

## 📘 작업 유형
- [x] ✨ Feature (기능 추가)
- [ ] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 Style (코드 스타일 수정)

## 📙 작업 내역
- `BookController` 및 `BookControllerApi`에 **내 서재 도서 삭제 API** 추가
- `BookUseCase`에 사용자 검증 및 삭제 로직 추가
- `UserBookService`에 삭제 메서드(`deleteUserBook`) 구현
- `UserBookDomainService`에서 도서 삭제 시 **연관된 독서 기록(ReadingRecord)도 함께 삭제** 처리
- `UserBookRepository`, `ReadingRecordRepository` 및 각 JPA 구현체에 `deleteById`, `deleteAllByUserBookId` 메서드 추가

## 🧪 테스트 내역
- [x] API 호출 시 정상적으로 도서와 연관 독서 기록 삭제 확인
- [x] 존재하지 않는 도서 ID 요청 시 404 응답 확인
- [x] 다른 사용자의 도서 삭제 시도 시 삭제 불가 확인
- [x] 기존 기능에 영향 없음 검증

## 🎨 스크린샷 또는 시연 영상 (선택)
| 기능 | 미리보기 |
|:--:|:--:|
| 삭제 API 호출 시 응답 예시 | <img src="API_CALL_RESPONSE_IMAGE_LINK" width="400" /> |

## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다

## 💬 추가 설명 or 리뷰 포인트 (선택)
- 삭제 시 도서와 관련된 **모든 독서 기록이 함께 제거**되도록 설계하였습니다.
- 추후 대량 삭제 기능이나 삭제 시 soft delete 적용 여부를 논의할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 인증된 사용자가 내 서재에서 특정 도서를 삭제할 수 있습니다 (DELETE /api/v1/books/my-library/{id}). 성공 시 204 No Content를 반환합니다.
  - 도서 삭제 시 해당 도서와 연동된 모든 독서 기록이 일괄 삭제되어 데이터 일관성이 유지됩니다.
  - 존재하지 않거나 권한이 없는 도서를 삭제하려 하면 404 오류와 안내 메시지를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->