### PR TITLE
독서 기록 pagenumber로 order by 시 페이징처리 동일한 id가 내려오는 상황

### DIFF
--- a/infra/src/main/kotlin/org/yapp/infra/readingrecord/repository/impl/JpaReadingRecordQuerydslRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecord/repository/impl/JpaReadingRecordQuerydslRepositoryImpl.kt
@@ -31,7 +31,7 @@ class JpaReadingRecordQuerydslRepositoryImpl(
         val results = queryFactory
             .selectFrom(readingRecord)
             .where(whereCondition)
-            .orderBy(createOrderSpecifier(sort))
+            .orderBy(*createOrderSpecifiers(sort))
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
@@ -45,13 +45,21 @@ class JpaReadingRecordQuerydslRepositoryImpl(
         return PageImpl(results, pageable, total)
     }
 
-    private fun createOrderSpecifier(sort: ReadingRecordSortType?): OrderSpecifier<*> {
+    private fun createOrderSpecifiers(sort: ReadingRecordSortType?): Array<OrderSpecifier<*>> {
         return when (sort) {
-            ReadingRecordSortType.PAGE_NUMBER_ASC -> readingRecord.pageNumber.asc()
-            ReadingRecordSortType.PAGE_NUMBER_DESC -> readingRecord.pageNumber.desc()
-            ReadingRecordSortType.CREATED_DATE_ASC -> readingRecord.createdAt.asc()
-            ReadingRecordSortType.CREATED_DATE_DESC -> readingRecord.createdAt.desc()
-            null -> readingRecord.createdAt.desc()
+            ReadingRecordSortType.PAGE_NUMBER_ASC -> arrayOf(
+                readingRecord.pageNumber.asc(),
+                readingRecord.updatedAt.desc()
+            )
+
+            ReadingRecordSortType.PAGE_NUMBER_DESC -> arrayOf(
+                readingRecord.pageNumber.desc(),
+                readingRecord.updatedAt.desc()
+            )
+
+            ReadingRecordSortType.CREATED_DATE_ASC -> arrayOf(readingRecord.createdAt.asc())
+            ReadingRecordSortType.CREATED_DATE_DESC -> arrayOf(readingRecord.createdAt.desc())
+            null -> arrayOf(readingRecord.createdAt.desc())
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #90

## 📘 작업 유형
- [x] 🐞 Bugfix (버그 수정)

## 📙 작업 내역
- `JpaReadingRecordQuerydslRepositoryImpl`의 정렬 조건 수정
  - `PAGE_NUMBER_ASC / DESC` 정렬 시 동일 `pageNumber`를 가진 데이터가 섞이지 않도록 `updatedAt.desc()` 보조 정렬 조건 추가
  - 기타 정렬(`CREATED_DATE_ASC / DESC`, 기본 정렬)은 기존 로직 유지

## 🧪 테스트 내역
- [x] `PAGE_NUMBER_ASC` 정렬 시 동일 페이지 번호 내 최신 수정 순서대로 정렬됨 확인
- [x] `PAGE_NUMBER_DESC` 정렬 시 동일 페이지 번호 내 최신 수정 순서대로 정렬됨 확인
- [x] 기존 `CREATED_DATE` 기준 정렬 영향 없음

## 💬 리뷰 포인트
- 보조 정렬 기준을 `updatedAt`으로 두는 게 적절한지, 혹은 `createdAt`이나 다른 기준이 더 나을지 확인 부탁드립니다.