### PR TITLE
fix: 탈퇴한 유저 재가입 시 기존 정보 복구되지 않는 문제 해결

### DIFF
--- a/infra/src/main/kotlin/org/yapp/infra/user/repository/JpaUserRepository.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/user/repository/JpaUserRepository.kt
@@ -17,11 +17,11 @@ interface JpaUserRepository : JpaRepository<UserEntity, UUID> {
     fun existsByEmail(email: String): Boolean
 
     @Query(
-        value = "SELECT * FROM users u WHERE u.provider_type = :providerType AND u.provider_id = :providerId",
+        value = "SELECT u.* FROM users u WHERE u.provider_type = :#{#providerType.name()} AND u.provider_id = :providerId",
         nativeQuery = true
     )
     fun findByProviderTypeAndProviderIdIncludingDeleted(
-        @Param("providerType") providerType: String,
+        @Param("providerType") providerType: ProviderType,
         @Param("providerId") providerId: String
     ): UserEntity?
 }

--- a/infra/src/main/kotlin/org/yapp/infra/user/repository/JpaUserRepository.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/user/repository/JpaUserRepository.kt
@@ -2,6 +2,7 @@ package org.yapp.infra.user.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.yapp.domain.user.ProviderType
 import org.yapp.infra.user.entity.UserEntity
 import java.util.*
@@ -15,6 +16,12 @@ interface JpaUserRepository : JpaRepository<UserEntity, UUID> {
 
     fun existsByEmail(email: String): Boolean
 
-    @Query("SELECT u FROM UserEntity u WHERE u.providerType = :providerType AND u.providerId = :providerId")
-    fun findByProviderTypeAndProviderIdIncludingDeleted(providerType: ProviderType, providerId: String): UserEntity?
+    @Query(
+        value = "SELECT * FROM users u WHERE u.provider_type = :providerType AND u.provider_id = :providerId",
+        nativeQuery = true
+    )
+    fun findByProviderTypeAndProviderIdIncludingDeleted(
+        @Param("providerType") providerType: String,
+        @Param("providerId") providerId: String
+    ): UserEntity?
 }

--- a/infra/src/main/kotlin/org/yapp/infra/user/repository/impl/UserRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/user/repository/impl/UserRepositoryImpl.kt
@@ -39,7 +39,7 @@ class UserRepositoryImpl(
         providerType: ProviderType,
         providerId: String
     ): User? {
-        return jpaUserRepository.findByProviderTypeAndProviderIdIncludingDeleted(providerType, providerId)?.toDomain()
+        return jpaUserRepository.findByProviderTypeAndProviderIdIncludingDeleted(providerType.name, providerId)?.toDomain()
     }
 
     override fun deleteById(userId: UUID) {

--- a/infra/src/main/kotlin/org/yapp/infra/user/repository/impl/UserRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/user/repository/impl/UserRepositoryImpl.kt
@@ -39,7 +39,7 @@ class UserRepositoryImpl(
         providerType: ProviderType,
         providerId: String
     ): User? {
-        return jpaUserRepository.findByProviderTypeAndProviderIdIncludingDeleted(providerType.name, providerId)?.toDomain()
+        return jpaUserRepository.findByProviderTypeAndProviderIdIncludingDeleted(providerType, providerId)?.toDomain()
     }
 
     override fun deleteById(userId: UUID) {


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #98 


## 📘 작업 유형
<!-- 아래에서 해당하는 항목에 [x] 표시해주세요 -->
- [ ] ✨ Feature (기능 추가)
- [x] 🐞 Bugfix (버그 수정)
- [x] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- SQLRestriction에 명시한 "deleted_at IS NULL"이 JPQL에서도 작동하여 회원 탈퇴 유저가 복구되지 않고 새롭게 가입이 되어 중복 저장되는 문제를 해결했습니다.


## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음


## 🎨 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 기능 설명 |<img src="링크" width="300" />| 기능 설명 |<img src="링크" width="300" />|


## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다


## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- 앞으로 soft-delete된 정보를 복구하는 로직을 작성할 때는 Native Query로 작업을 진행해야 할 것 같습니다!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 사용자 연동 정보(제공자 유형/ID)로 사용자를 조회하는 내부 처리 방식을 재구성했습니다. 삭제된 계정을 포함한 조회의 일관성과 안정성이 강화되었으며, 화면 또는 API 동작의 변경은 없습니다.
- Chores
  - 내부 매개변수 바인딩 정의를 명시적으로 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->