### PR TITLE
refactor: 독서태그 N+1문제를 해결합니다.

### DIFF
--- a/domain/src/main/kotlin/org/yapp/domain/readingrecordtag/ReadingRecordTagRepository.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecordtag/ReadingRecordTagRepository.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 interface ReadingRecordTagRepository {
     fun saveAll(readingRecordTags: List<ReadingRecordTag>): List<ReadingRecordTag>
     fun findByReadingRecordId(readingRecordId: UUID): List<ReadingRecordTag>
+    fun findByReadingRecordIdIn(readingRecordIds: List<UUID>): List<ReadingRecordTag>
     fun deleteAllByReadingRecordId(readingRecordId: UUID)
     fun countTagsByUserIdAndUserBookIdAndCategories(userId: UUID, userBookId: UUID, categories: List<String>): Map<String, Int>
 }

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecordtag/repository/JpaReadingRecordTagRepository.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecordtag/repository/JpaReadingRecordTagRepository.kt
@@ -6,5 +6,6 @@ import java.util.*
 
 interface JpaReadingRecordTagRepository : JpaRepository<ReadingRecordTagEntity, UUID>, JpaReadingRecordTagQuerydslRepository {
     fun findByReadingRecordId(readingRecordId: UUID): List<ReadingRecordTagEntity>
+    fun findByReadingRecordIdIn(readingRecordIds: List<UUID>): List<ReadingRecordTagEntity>
     fun deleteAllByReadingRecordId(readingRecordId: UUID)
 }

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecordtag/repository/impl/ReadingRecordTagRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecordtag/repository/impl/ReadingRecordTagRepositoryImpl.kt
@@ -20,6 +20,10 @@ class ReadingRecordTagRepositoryImpl(
         return jpaReadingRecordTagRepository.findByReadingRecordId(readingRecordId).map { it.toDomain() }
     }
 
+    override fun findByReadingRecordIdIn(readingRecordIds: List<UUID>): List<ReadingRecordTag> {
+        return jpaReadingRecordTagRepository.findByReadingRecordIdIn(readingRecordIds).map { it.toDomain() }
+    }
+
     override fun countTagsByUserIdAndUserBookIdAndCategories(userId: UUID, userBookId: UUID, categories: List<String>): Map<String, Int> {
         return jpaReadingRecordTagRepository.countTagsByUserIdAndUserBookIdAndCategories(userId, userBookId, categories)
     }

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecordtag/repository/impl/ReadingRecordTagRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecordtag/repository/impl/ReadingRecordTagRepositoryImpl.kt
@@ -21,10 +21,17 @@ class ReadingRecordTagRepositoryImpl(
     }
 
     override fun findByReadingRecordIdIn(readingRecordIds: List<UUID>): List<ReadingRecordTag> {
-        return jpaReadingRecordTagRepository.findByReadingRecordIdIn(readingRecordIds).map { it.toDomain() }
+        if (readingRecordIds.isEmpty()) return emptyList()
+        return jpaReadingRecordTagRepository
+            .findByReadingRecordIdIn(readingRecordIds)
+            .map { it.toDomain() }
     }
 
-    override fun countTagsByUserIdAndUserBookIdAndCategories(userId: UUID, userBookId: UUID, categories: List<String>): Map<String, Int> {
+    override fun countTagsByUserIdAndUserBookIdAndCategories(
+        userId: UUID,
+        userBookId: UUID,
+        categories: List<String>
+    ): Map<String, Int> {
         return jpaReadingRecordTagRepository.countTagsByUserIdAndUserBookIdAndCategories(userId, userBookId, categories)
     }
 


### PR DESCRIPTION
## 📘 작업 유형
- [x] ✨ Feature (기능 추가)
- close #54 

## 📙 작업 내역
- `ReadingRecordTagRepository` 인터페이스에 `findByReadingRecordIdIn` 메서드 추가
- `JpaReadingRecordTagRepository` 에 `findByReadingRecordIdIn` 메서드 추가
- `ReadingRecordTagRepositoryImpl` 구현체에 `findByReadingRecordIdIn` 메서드 구현
- `ReadingRecordService` 내 `getReadingRecords` 로직 개선  
  - 조회된 `readingRecord` 들의 ID를 기반으로 태그를 일괄 조회하도록 변경  
  - 성능 최적화를 위해 `readingRecordTags`를 미리 그룹핑 후 매핑하는 방식으로 수정  

## 🧪 테스트 내역
- [x] 다수의 `readingRecord` 조회 시 태그가 정상적으로 매핑되는지 확인  
- [x] 태그가 없는 경우 `Page.empty(pageable)` 정상 반환 확인  
- [x] 기존 기능 동작에 영향 없음 확인  

## 🎨 스크린샷 또는 시연 영상 (선택)
해당 없음

## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다

## 💬 추가 설명 or 리뷰 포인트
- 다중 `readingRecordId` 기반으로 태그를 조회할 수 있는 기능이 추가되어 향후 API 성능 최적화에 활용될 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 독서 기록 목록과 태그 로딩이 더 빨라져 목록 화면 응답 속도가 향상되었습니다.
  * 여러 기록을 한 번에 불러와 대량 데이터 처리 시 일관된 성능을 제공합니다.
* **리팩터**
  * 데이터 조회 흐름을 일괄화해 중복 호출을 줄이고 효율을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->