### PR TITLE
fix: 내서재와 독서기록 기본정렬을 수정합니다.

### DIFF
--- a/apis/src/main/kotlin/org/yapp/apis/book/controller/BookController.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/controller/BookController.kt
@@ -71,7 +71,7 @@ class BookController(
         @RequestParam(required = false) status: BookStatus?,
         @RequestParam(required = false) sort: UserBookSortType?,
         @RequestParam(required = false) title: String?,
-        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        @PageableDefault(size = 10, sort = ["updatedAt"], direction = Sort.Direction.DESC)
         pageable: Pageable
     ): ResponseEntity<UserBookPageResponse> {
         val response = bookUseCase.getUserLibraryBooks(userId, status, sort, title, pageable)

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordController.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordController.kt
@@ -63,7 +63,7 @@ class ReadingRecordController(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable userBookId: UUID,
         @RequestParam(required = false) sort: ReadingRecordSortType?,
-        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        @PageableDefault(size = 10, sort = ["updatedAt"], direction = Sort.Direction.DESC)
         pageable: Pageable
     ): ResponseEntity<ReadingRecordPageResponse> {
         val response = readingRecordUseCase.getReadingRecordsByUserBookId(

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecordSortType.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecordSortType.kt
@@ -3,6 +3,8 @@ package org.yapp.domain.readingrecord
 enum class ReadingRecordSortType {
     CREATED_DATE_ASC,
     CREATED_DATE_DESC,
+    UPDATED_DATE_ASC,
+    UPDATED_DATE_DESC,
     PAGE_NUMBER_ASC,
     PAGE_NUMBER_DESC;
 }

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecord/repository/impl/JpaReadingRecordQuerydslRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecord/repository/impl/JpaReadingRecordQuerydslRepositoryImpl.kt
@@ -59,7 +59,9 @@ class JpaReadingRecordQuerydslRepositoryImpl(
 
             ReadingRecordSortType.CREATED_DATE_ASC -> arrayOf(readingRecord.createdAt.asc())
             ReadingRecordSortType.CREATED_DATE_DESC -> arrayOf(readingRecord.createdAt.desc())
-            null -> arrayOf(readingRecord.createdAt.desc())
+            ReadingRecordSortType.UPDATED_DATE_ASC -> arrayOf(readingRecord.updatedAt.asc())
+            ReadingRecordSortType.UPDATED_DATE_DESC -> arrayOf(readingRecord.updatedAt.desc())
+            null -> arrayOf(readingRecord.updatedAt.desc())
         }
     }
 


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
[BOOK-324] fix: 내서재와 독서기록 기본정렬 수정
-->

## 🔗 관련 이슈
- Close #이슈번호
- 예: Close #117

## 📘 작업 유형
- [ ] ✨ Feature (기능 추가)
- [x] 🐞 Bugfix (버그 수정)
- [ ] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)

## 📙 작업 내역
- 내서재(BookController) 기본 정렬 기준을 `createdAt` → `updatedAt`로 수정
- 독서기록(ReadingRecordController) 기본 정렬 기준을 `createdAt` → `updatedAt`로 수정
- ReadingRecordSortType에 `UPDATED_DATE_ASC` / `UPDATED_DATE_DESC` 추가
- JpaReadingRecordQuerydslRepositoryImpl에서 업데이트 날짜 기준 정렬 로직 반영

## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [x] 기존 기능 영향 없음 (정렬 기준만 변경)
- [x] 페이지네이션 및 정렬 엣지 케이스 테스트 완료

## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다

## 💬 추가 설명 or 리뷰 포인트
- ReadingRecordSortType 업데이트로 인해 기존 쿼리 로직에 영향이 없는지 확인 필요
- 기본 정렬 변경이 사용자 경험에 문제 없는지 확인


[BOOK-324]: https://booket.atlassian.net/browse/BOOK-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 사용자 라이브러리 도서 목록과 독서 기록 목록의 기본 정렬이 생성일 기준에서 수정일 최신순으로 변경되어, 최근에 업데이트된 항목이 먼저 표시됩니다.
  - 정렬 옵션에 ‘수정일 오름차순/내림차순’이 추가되어, 목록을 수정일 기준으로 세밀하게 정렬할 수 있습니다. 기존 파라미터 사용 방식은 동일하며, 기본 정렬 동작만 변경됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->