### PR TITLE
feat: 독서 기록 V2 API 및 대분류/세부 감정 시스템 구현

### DIFF
--- a/apis/src/main/kotlin/org/yapp/apis/book/exception/UserBookErrorCode.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/exception/UserBookErrorCode.kt
@@ -8,8 +8,7 @@ enum class UserBookErrorCode(
     private val code: String,
     private val message: String
 ) : BaseErrorCode {
-
-    USER_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_BOOK_404_01", "사용자의 책을 찾을 수 없습니다.");
+    USER_BOOK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "USER_BOOK_403_01", "해당 책에 대한 접근 권한이 없습니다.");
 
     override fun getHttpStatus(): HttpStatus = httpStatus
     override fun getCode(): String = code

--- a/apis/src/main/kotlin/org/yapp/apis/book/service/UserBookService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/book/service/UserBookService.kt
@@ -43,8 +43,8 @@ class UserBookService(
     fun validateUserBookExists(userBookId: UUID, userId: UUID) {
         if (!userBookDomainService.existsByUserBookIdAndUserId(userBookId, userId)) {
             throw UserBookException(
-                UserBookErrorCode.USER_BOOK_NOT_FOUND,
-                "UserBook not found or access denied: $userBookId"
+                UserBookErrorCode.USER_BOOK_ACCESS_DENIED,
+                "UserBook access denied: $userBookId"
             )
         }
     }

--- a/apis/src/main/kotlin/org/yapp/apis/emotion/controller/EmotionController.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/emotion/controller/EmotionController.kt
@@ -1,0 +1,21 @@
+package org.yapp.apis.emotion.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.yapp.apis.emotion.dto.response.EmotionListResponse
+import org.yapp.apis.emotion.service.EmotionService
+
+@RestController
+@RequestMapping("/api/v2/emotions")
+class EmotionController(
+    private val emotionService: EmotionService
+) : EmotionControllerApi {
+
+    @GetMapping
+    override fun getEmotions(): ResponseEntity<EmotionListResponse> {
+        val response = emotionService.getEmotionList()
+        return ResponseEntity.ok(response)
+    }
+}

--- a/apis/src/main/kotlin/org/yapp/apis/emotion/controller/EmotionControllerApi.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/emotion/controller/EmotionControllerApi.kt
@@ -1,0 +1,33 @@
+package org.yapp.apis.emotion.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.yapp.apis.emotion.dto.response.EmotionListResponse
+
+@Tag(name = "Emotions", description = "감정 관련 API")
+@RequestMapping("/api/v2/emotions")
+interface EmotionControllerApi {
+
+    @Operation(
+        summary = "감정 목록 조회",
+        description = "대분류 감정과 세부 감정 목록을 조회합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "감정 목록 조회 성공",
+                content = [Content(schema = Schema(implementation = EmotionListResponse::class))]
+            )
+        ]
+    )
+    @GetMapping
+    fun getEmotions(): ResponseEntity<EmotionListResponse>
+}

--- a/apis/src/main/kotlin/org/yapp/apis/emotion/dto/response/EmotionListResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/emotion/dto/response/EmotionListResponse.kt
@@ -6,47 +6,67 @@ import org.yapp.domain.readingrecord.PrimaryEmotion
 import java.util.UUID
 
 @Schema(name = "EmotionListResponse", description = "감정 목록 응답")
-data class EmotionListResponse(
+data class EmotionListResponse private constructor(
     @field:Schema(description = "감정 그룹 목록")
     val emotions: List<EmotionGroupDto>
 ) {
     companion object {
         fun from(detailTags: List<DetailTag>): EmotionListResponse {
             val grouped = detailTags.groupBy { it.primaryEmotion }
-            
+
             val emotions = PrimaryEmotion.entries.map { primary ->
-                EmotionGroupDto(
+                EmotionGroupDto.of(
                     code = primary.name,
                     displayName = primary.displayName,
                     detailEmotions = grouped[primary]
                         ?.sortedBy { it.displayOrder }
-                        ?.map { EmotionDetailDto(id = it.id.value, name = it.name) }
+                        ?.map { EmotionDetailDto.of(id = it.id.value, name = it.name) }
                         ?: emptyList()
                 )
             }
-            
+
             return EmotionListResponse(emotions = emotions)
         }
     }
+
+    @Schema(name = "EmotionGroupDto", description = "감정 그룹 (대분류 + 세부감정)")
+    data class EmotionGroupDto private constructor(
+        @field:Schema(description = "대분류 코드", example = "JOY")
+        val code: String,
+
+        @field:Schema(description = "대분류 표시 이름", example = "즐거움")
+        val displayName: String,
+
+        @field:Schema(description = "세부 감정 목록")
+        val detailEmotions: List<EmotionDetailDto>
+    ) {
+        companion object {
+            fun of(
+                code: String,
+                displayName: String,
+                detailEmotions: List<EmotionDetailDto>
+            ): EmotionGroupDto {
+                return EmotionGroupDto(
+                    code = code,
+                    displayName = displayName,
+                    detailEmotions = detailEmotions
+                )
+            }
+        }
+    }
+
+    @Schema(name = "EmotionDetailDto", description = "세부 감정")
+    data class EmotionDetailDto private constructor(
+        @field:Schema(description = "세부 감정 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+        val id: UUID,
+
+        @field:Schema(description = "세부 감정 이름", example = "설레는")
+        val name: String
+    ) {
+        companion object {
+            fun of(id: UUID, name: String): EmotionDetailDto {
+                return EmotionDetailDto(id = id, name = name)
+            }
+        }
+    }
 }
-
-@Schema(name = "EmotionGroupDto", description = "감정 그룹 (대분류 + 세부감정)")
-data class EmotionGroupDto(
-    @field:Schema(description = "대분류 코드", example = "JOY")
-    val code: String,
-
-    @field:Schema(description = "대분류 표시 이름", example = "즐거움")
-    val displayName: String,
-
-    @field:Schema(description = "세부 감정 목록")
-    val detailEmotions: List<EmotionDetailDto>
-)
-
-@Schema(name = "EmotionDetailDto", description = "세부 감정")
-data class EmotionDetailDto(
-    @field:Schema(description = "세부 감정 ID", example = "123e4567-e89b-12d3-a456-426614174000")
-    val id: UUID,
-
-    @field:Schema(description = "세부 감정 이름", example = "설레는")
-    val name: String
-)

--- a/apis/src/main/kotlin/org/yapp/apis/emotion/dto/response/EmotionListResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/emotion/dto/response/EmotionListResponse.kt
@@ -1,0 +1,52 @@
+package org.yapp.apis.emotion.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.yapp.domain.detailtag.DetailTag
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import java.util.UUID
+
+@Schema(name = "EmotionListResponse", description = "감정 목록 응답")
+data class EmotionListResponse(
+    @field:Schema(description = "감정 그룹 목록")
+    val emotions: List<EmotionGroupDto>
+) {
+    companion object {
+        fun from(detailTags: List<DetailTag>): EmotionListResponse {
+            val grouped = detailTags.groupBy { it.primaryEmotion }
+            
+            val emotions = PrimaryEmotion.entries.map { primary ->
+                EmotionGroupDto(
+                    code = primary.name,
+                    displayName = primary.displayName,
+                    detailEmotions = grouped[primary]
+                        ?.sortedBy { it.displayOrder }
+                        ?.map { EmotionDetailDto(id = it.id.value, name = it.name) }
+                        ?: emptyList()
+                )
+            }
+            
+            return EmotionListResponse(emotions = emotions)
+        }
+    }
+}
+
+@Schema(name = "EmotionGroupDto", description = "감정 그룹 (대분류 + 세부감정)")
+data class EmotionGroupDto(
+    @field:Schema(description = "대분류 코드", example = "JOY")
+    val code: String,
+
+    @field:Schema(description = "대분류 표시 이름", example = "즐거움")
+    val displayName: String,
+
+    @field:Schema(description = "세부 감정 목록")
+    val detailEmotions: List<EmotionDetailDto>
+)
+
+@Schema(name = "EmotionDetailDto", description = "세부 감정")
+data class EmotionDetailDto(
+    @field:Schema(description = "세부 감정 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val id: UUID,
+
+    @field:Schema(description = "세부 감정 이름", example = "설레는")
+    val name: String
+)

--- a/apis/src/main/kotlin/org/yapp/apis/emotion/service/EmotionService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/emotion/service/EmotionService.kt
@@ -1,0 +1,16 @@
+package org.yapp.apis.emotion.service
+
+import org.yapp.apis.emotion.dto.response.EmotionListResponse
+import org.yapp.domain.detailtag.DetailTagDomainService
+import org.yapp.globalutils.annotation.ApplicationService
+
+@ApplicationService
+class EmotionService(
+    private val detailTagDomainService: DetailTagDomainService
+) {
+    fun getEmotionList(): EmotionListResponse {
+        val detailTags = detailTagDomainService.findAll()
+        return EmotionListResponse.from(detailTags)
+    }
+}
+

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
@@ -1,0 +1,153 @@
+package org.yapp.apis.readingrecord.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequestV2
+import org.yapp.apis.readingrecord.dto.request.UpdateReadingRecordRequestV2
+import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponseV2
+import org.yapp.domain.readingrecord.ReadingRecordSortType
+import org.yapp.globalutils.exception.ErrorResponse
+import java.util.*
+
+@Tag(name = "Reading Records V2", description = "독서 기록 관련 API (V2)")
+@RequestMapping("/api/v2/reading-records")
+interface ReadingRecordControllerApiV2 {
+
+    @Operation(
+        summary = "독서 기록 생성 (V2)",
+        description = "사용자의 책에 대한 독서 기록을 생성합니다. 대분류 감정은 필수, 세부 감정은 선택입니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "독서 기록 생성 성공",
+                content = [Content(schema = Schema(implementation = ReadingRecordResponseV2::class))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자 또는 책을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @PostMapping("/{userBookId}")
+    fun createReadingRecord(
+        @AuthenticationPrincipal @Parameter(description = "인증된 사용자 ID") userId: UUID,
+        @PathVariable @Parameter(description = "독서 기록을 생성할 사용자 책 ID") userBookId: UUID,
+        @Valid @RequestBody @Parameter(description = "독서 기록 생성 요청 객체") request: CreateReadingRecordRequestV2
+    ): ResponseEntity<ReadingRecordResponseV2>
+
+    @Operation(
+        summary = "독서 기록 상세 조회 (V2)",
+        description = "독서 기록 ID로 독서 기록 상세 정보를 조회합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "독서 기록 상세 조회 성공",
+                content = [Content(schema = Schema(implementation = ReadingRecordResponseV2::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자 또는 독서 기록을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @GetMapping("/detail/{readingRecordId}")
+    fun getReadingRecordDetail(
+        @AuthenticationPrincipal @Parameter(description = "인증된 사용자 ID") userId: UUID,
+        @PathVariable @Parameter(description = "조회할 독서 기록 ID") readingRecordId: UUID
+    ): ResponseEntity<ReadingRecordResponseV2>
+
+    @Operation(
+        summary = "독서 기록 목록 조회 (V2)",
+        description = "사용자의 책에 대한 독서 기록을 페이징하여 조회합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "독서 기록 목록 조회 성공"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자 또는 책을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @GetMapping("/{userBookId}")
+    fun getReadingRecords(
+        @AuthenticationPrincipal @Parameter(description = "인증된 사용자 ID") userId: UUID,
+        @PathVariable @Parameter(description = "독서 기록을 조회할 사용자 책 ID") userBookId: UUID,
+        @RequestParam(required = false) @Parameter(description = "정렬 타입") sort: ReadingRecordSortType?,
+        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        @Parameter(description = "페이징 정보") pageable: Pageable
+    ): ResponseEntity<Page<ReadingRecordResponseV2>>
+
+    @Operation(
+        summary = "독서 기록 수정 (V2)",
+        description = "독서 기록을 수정합니다. 대분류 감정과 세부 감정을 변경할 수 있습니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "독서 기록 수정 성공",
+                content = [Content(schema = Schema(implementation = ReadingRecordResponseV2::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "독서 기록을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @PutMapping("/{readingRecordId}")
+    fun updateReadingRecord(
+        @AuthenticationPrincipal @Parameter(description = "인증된 사용자 ID") userId: UUID,
+        @PathVariable @Parameter(description = "수정할 독서 기록 ID") readingRecordId: UUID,
+        @Valid @RequestBody @Parameter(description = "독서 기록 수정 요청 객체") request: UpdateReadingRecordRequestV2
+    ): ResponseEntity<ReadingRecordResponseV2>
+
+    @Operation(
+        summary = "독서 기록 삭제",
+        description = "독서 기록을 삭제합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "독서 기록 삭제 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "독서 기록을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @DeleteMapping("/{readingRecordId}")
+    fun deleteReadingRecord(
+        @AuthenticationPrincipal @Parameter(description = "인증된 사용자 ID") userId: UUID,
+        @PathVariable @Parameter(description = "삭제할 독서 기록 ID") readingRecordId: UUID
+    ): ResponseEntity<Void>
+}

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
@@ -82,7 +82,7 @@ interface ReadingRecordControllerApiV2 {
 
     @Operation(
         summary = "독서 기록 목록 조회 (V2)",
-        description = "사용자의 책에 대한 독서 기록을 페이징하여 조회합니다."
+        description = "사용자의 책에 대한 독서 기록을 페이징하여 조회합니다. sort 파라미터가 지정된 경우 해당 정렬이 우선 적용되며, 지정하지 않으면 기본 정렬(updatedAt DESC)이 적용됩니다."
     )
     @ApiResponses(
         value = [
@@ -101,9 +101,11 @@ interface ReadingRecordControllerApiV2 {
     fun getReadingRecords(
         @AuthenticationPrincipal @Parameter(description = "인증된 사용자 ID") userId: UUID,
         @PathVariable @Parameter(description = "독서 기록을 조회할 사용자 책 ID") userBookId: UUID,
-        @RequestParam(required = false) @Parameter(description = "정렬 타입") sort: ReadingRecordSortType?,
-        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
-        @Parameter(description = "페이징 정보") pageable: Pageable
+        @RequestParam(required = false) @Parameter(
+            description = "정렬 타입 (PAGE_NUMBER_ASC, PAGE_NUMBER_DESC, CREATED_DATE_ASC, CREATED_DATE_DESC, UPDATED_DATE_ASC, UPDATED_DATE_DESC). 지정 시 Pageable의 sort보다 우선 적용됨"
+        ) sort: ReadingRecordSortType?,
+        @PageableDefault(size = 10, sort = ["updatedAt"], direction = Sort.Direction.DESC)
+        @Parameter(description = "페이지네이션 정보 (기본값: 10개). 정렬은 sort 파라미터로 제어되며, Pageable의 sort는 무시됩니다.") pageable: Pageable
     ): ResponseEntity<Page<ReadingRecordResponseV2>>
 
     @Operation(

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
@@ -43,6 +43,11 @@ interface ReadingRecordControllerApiV2 {
                 content = [Content(schema = Schema(implementation = ErrorResponse::class))]
             ),
             ApiResponse(
+                responseCode = "403",
+                description = "해당 책에 대한 접근 권한이 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
                 responseCode = "404",
                 description = "사용자 또는 책을 찾을 수 없음",
                 content = [Content(schema = Schema(implementation = ErrorResponse::class))]

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
@@ -166,5 +166,5 @@ interface ReadingRecordControllerApiV2 {
     fun deleteReadingRecord(
         @AuthenticationPrincipal @Parameter(description = "인증된 사용자 ID") userId: UUID,
         @PathVariable @Parameter(description = "삭제할 독서 기록 ID") readingRecordId: UUID
-    ): ResponseEntity<Void>
+    ): ResponseEntity<Unit>
 }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerApiV2.kt
@@ -68,6 +68,11 @@ interface ReadingRecordControllerApiV2 {
                 content = [Content(schema = Schema(implementation = ReadingRecordResponseV2::class))]
             ),
             ApiResponse(
+                responseCode = "403",
+                description = "해당 독서 기록에 대한 접근 권한이 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
                 responseCode = "404",
                 description = "사용자 또는 독서 기록을 찾을 수 없음",
                 content = [Content(schema = Schema(implementation = ErrorResponse::class))]
@@ -120,6 +125,11 @@ interface ReadingRecordControllerApiV2 {
                 content = [Content(schema = Schema(implementation = ReadingRecordResponseV2::class))]
             ),
             ApiResponse(
+                responseCode = "403",
+                description = "해당 독서 기록에 대한 접근 권한이 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
                 responseCode = "404",
                 description = "독서 기록을 찾을 수 없음",
                 content = [Content(schema = Schema(implementation = ErrorResponse::class))]
@@ -140,6 +150,11 @@ interface ReadingRecordControllerApiV2 {
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "204", description = "독서 기록 삭제 성공"),
+            ApiResponse(
+                responseCode = "403",
+                description = "해당 독서 기록에 대한 접근 권한이 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
             ApiResponse(
                 responseCode = "404",
                 description = "독서 기록을 찾을 수 없음",

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerV2.kt
@@ -83,7 +83,7 @@ class ReadingRecordControllerV2(
     override fun deleteReadingRecord(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable readingRecordId: UUID
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         readingRecordUseCaseV2.deleteReadingRecord(userId, readingRecordId)
         return ResponseEntity.noContent().build()
     }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerV2.kt
@@ -1,0 +1,90 @@
+package org.yapp.apis.readingrecord.controller
+
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequestV2
+import org.yapp.apis.readingrecord.dto.request.UpdateReadingRecordRequestV2
+import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponseV2
+import org.yapp.apis.readingrecord.usecase.ReadingRecordUseCaseV2
+import org.yapp.domain.readingrecord.ReadingRecordSortType
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v2/reading-records")
+class ReadingRecordControllerV2(
+    private val readingRecordUseCaseV2: ReadingRecordUseCaseV2
+) : ReadingRecordControllerApiV2 {
+
+    @PostMapping("/{userBookId}")
+    override fun createReadingRecord(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable userBookId: UUID,
+        @Valid @RequestBody request: CreateReadingRecordRequestV2
+    ): ResponseEntity<ReadingRecordResponseV2> {
+        val response = readingRecordUseCaseV2.createReadingRecord(
+            userId = userId,
+            userBookId = userBookId,
+            request = request
+        )
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @GetMapping("/detail/{readingRecordId}")
+    override fun getReadingRecordDetail(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable readingRecordId: UUID
+    ): ResponseEntity<ReadingRecordResponseV2> {
+        val response = readingRecordUseCaseV2.getReadingRecordDetail(
+            userId = userId,
+            readingRecordId = readingRecordId
+        )
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/{userBookId}")
+    override fun getReadingRecords(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable userBookId: UUID,
+        @RequestParam(required = false) sort: ReadingRecordSortType?,
+        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        pageable: Pageable
+    ): ResponseEntity<Page<ReadingRecordResponseV2>> {
+        val response = readingRecordUseCaseV2.getReadingRecordsByUserBookId(
+            userId = userId,
+            userBookId = userBookId,
+            sort = sort,
+            pageable = pageable
+        )
+        return ResponseEntity.ok(response)
+    }
+
+    @PutMapping("/{readingRecordId}")
+    override fun updateReadingRecord(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable readingRecordId: UUID,
+        @Valid @RequestBody request: UpdateReadingRecordRequestV2
+    ): ResponseEntity<ReadingRecordResponseV2> {
+        val response = readingRecordUseCaseV2.updateReadingRecord(
+            userId = userId,
+            readingRecordId = readingRecordId,
+            request = request
+        )
+        return ResponseEntity.ok(response)
+    }
+
+    @DeleteMapping("/{readingRecordId}")
+    override fun deleteReadingRecord(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable readingRecordId: UUID
+    ): ResponseEntity<Void> {
+        readingRecordUseCaseV2.deleteReadingRecord(userId, readingRecordId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerV2.kt
@@ -53,7 +53,7 @@ class ReadingRecordControllerV2(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable userBookId: UUID,
         @RequestParam(required = false) sort: ReadingRecordSortType?,
-        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        @PageableDefault(size = 10, sort = ["updatedAt"], direction = Sort.Direction.DESC)
         pageable: Pageable
     ): ResponseEntity<Page<ReadingRecordResponseV2>> {
         val response = readingRecordUseCaseV2.getReadingRecordsByUserBookId(

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/CreateReadingRecordRequest.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/CreateReadingRecordRequest.kt
@@ -43,6 +43,4 @@ data class CreateReadingRecordRequest private constructor(
 
     fun validQuote(): String =
         requireNotNull(quote) { "quote는 null일 수 없습니다." }
-    
-    fun validEmotionTags(): List<String> = emotionTags
 }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/CreateReadingRecordRequestV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/CreateReadingRecordRequestV2.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.yapp.domain.readingrecord.PrimaryEmotion
 import java.util.UUID
@@ -37,6 +38,7 @@ data class CreateReadingRecordRequestV2 private constructor(
     @field:Schema(description = "감상평", example = "이 책은 매우 인상적이었습니다.", required = false)
     val review: String? = null,
 
+    @field:NotNull(message = "대분류 감정은 필수입니다.")
     @field:Schema(description = "대분류 감정", example = "JOY", required = true)
     val primaryEmotion: PrimaryEmotion? = null,
 

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/CreateReadingRecordRequestV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/CreateReadingRecordRequestV2.kt
@@ -45,9 +45,6 @@ data class CreateReadingRecordRequestV2 private constructor(
     @field:Schema(description = "세부 감정 태그 ID 목록 (선택, 다중 선택 가능)", example = "[\"uuid-1\", \"uuid-2\"]")
     val detailEmotionTagIds: List<UUID> = emptyList()
 ) {
-    fun validQuote(): String =
-        requireNotNull(quote) { "quote는 null일 수 없습니다." }
-
-    fun validPrimaryEmotion(): PrimaryEmotion =
-        requireNotNull(primaryEmotion) { "primaryEmotion은 null일 수 없습니다." }
+    fun validQuote(): String = quote!!
+    fun validPrimaryEmotion(): PrimaryEmotion = primaryEmotion!!
 }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/CreateReadingRecordRequestV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/CreateReadingRecordRequestV2.kt
@@ -1,0 +1,51 @@
+package org.yapp.apis.readingrecord.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import java.util.UUID
+
+@Schema(
+    name = "CreateReadingRecordRequestV2",
+    description = "독서 기록 생성 요청 (V2)",
+    example = """
+        {
+          "pageNumber": 42,
+          "quote": "이것은 기억에 남는 문장입니다.",
+          "review": "이 책은 매우 인상적이었습니다.",
+          "primaryEmotion": "JOY",
+          "detailEmotionTagIds": ["uuid-1", "uuid-2"]
+        }
+    """
+)
+data class CreateReadingRecordRequestV2 private constructor(
+
+    @field:Min(1, message = "페이지 번호는 1 이상이어야 합니다.")
+    @field:Max(9999, message = "페이지 번호는 9999 이하여야 합니다.")
+    @field:Schema(description = "현재 읽은 페이지 번호", example = "42", required = false)
+    val pageNumber: Int? = null,
+
+    @field:NotBlank(message = "기억에 남는 문장은 필수입니다.")
+    @field:Size(max = 1000, message = "기억에 남는 문장은 1000자를 초과할 수 없습니다.")
+    @field:Schema(description = "기억에 남는 문장", example = "이것은 기억에 남는 문장입니다.", required = true)
+    val quote: String? = null,
+
+    @field:Size(max = 1000, message = "감상평은 1000자를 초과할 수 없습니다.")
+    @field:Schema(description = "감상평", example = "이 책은 매우 인상적이었습니다.", required = false)
+    val review: String? = null,
+
+    @field:Schema(description = "대분류 감정", example = "JOY", required = true)
+    val primaryEmotion: PrimaryEmotion? = null,
+
+    @field:Schema(description = "세부 감정 태그 ID 목록 (선택, 다중 선택 가능)", example = "[\"uuid-1\", \"uuid-2\"]")
+    val detailEmotionTagIds: List<UUID> = emptyList()
+) {
+    fun validQuote(): String =
+        requireNotNull(quote) { "quote는 null일 수 없습니다." }
+
+    fun validPrimaryEmotion(): PrimaryEmotion =
+        requireNotNull(primaryEmotion) { "primaryEmotion은 null일 수 없습니다." }
+}

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/UpdateReadingRecordRequestV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/UpdateReadingRecordRequestV2.kt
@@ -11,7 +11,7 @@ import java.util.UUID
     name = "UpdateReadingRecordRequestV2",
     description = "독서 기록 수정 요청 (V2)"
 )
-data class UpdateReadingRecordRequestV2(
+data class UpdateReadingRecordRequestV2 private constructor(
 
     @field:Min(1, message = "페이지 번호는 1 이상이어야 합니다.")
     @field:Max(9999, message = "페이지 번호는 9999 이하여야 합니다.")

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/UpdateReadingRecordRequestV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/request/UpdateReadingRecordRequestV2.kt
@@ -1,0 +1,34 @@
+package org.yapp.apis.readingrecord.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import java.util.UUID
+
+@Schema(
+    name = "UpdateReadingRecordRequestV2",
+    description = "독서 기록 수정 요청 (V2)"
+)
+data class UpdateReadingRecordRequestV2(
+
+    @field:Min(1, message = "페이지 번호는 1 이상이어야 합니다.")
+    @field:Max(9999, message = "페이지 번호는 9999 이하여야 합니다.")
+    @field:Schema(description = "현재 읽은 페이지 번호", example = "42")
+    val pageNumber: Int? = null,
+
+    @field:Size(max = 1000, message = "기억에 남는 문장은 1000자를 초과할 수 없습니다.")
+    @field:Schema(description = "기억에 남는 문장", example = "이것은 기억에 남는 문장입니다.")
+    val quote: String? = null,
+
+    @field:Size(max = 1000, message = "감상평은 1000자를 초과할 수 없습니다.")
+    @field:Schema(description = "감상평", example = "이 책은 매우 인상적이었습니다.")
+    val review: String? = null,
+
+    @field:Schema(description = "대분류 감정", example = "JOY")
+    val primaryEmotion: PrimaryEmotion? = null,
+
+    @field:Schema(description = "세부 감정 태그 ID 목록 (null이면 변경하지 않음)")
+    val detailEmotionTagIds: List<UUID>? = null
+)

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponse.kt
@@ -17,7 +17,7 @@ data class ReadingRecordResponse private constructor(
     @field:Schema(description = "사용자 책 ID", example = "123e4567-e89b-12d3-a456-426614174000")
     val userBookId: UUID,
 
-    @field:Schema(description = "현재 읽은 페이지 번호", example = "42")
+    @field:Schema(description = "현재 읽은 페이지 번호 (선택)", example = "42")
     val pageNumber: Int?,
 
     @field:Schema(description = "기억에 남는 문장", example = "이것은 기억에 남는 문장입니다.")

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponse.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponse.kt
@@ -18,7 +18,7 @@ data class ReadingRecordResponse private constructor(
     val userBookId: UUID,
 
     @field:Schema(description = "현재 읽은 페이지 번호", example = "42")
-    val pageNumber: Int,
+    val pageNumber: Int?,
 
     @field:Schema(description = "기억에 남는 문장", example = "이것은 기억에 남는 문장입니다.")
     val quote: String,
@@ -54,7 +54,7 @@ data class ReadingRecordResponse private constructor(
             return ReadingRecordResponse(
                 id = readingRecordInfoVO.id.value,
                 userBookId = readingRecordInfoVO.userBookId.value,
-                pageNumber = readingRecordInfoVO.pageNumber.value,
+                pageNumber = readingRecordInfoVO.pageNumber?.value,
                 quote = readingRecordInfoVO.quote.value,
                 review = readingRecordInfoVO.review?.value,
                 emotionTags = readingRecordInfoVO.emotionTags,
@@ -68,3 +68,4 @@ data class ReadingRecordResponse private constructor(
         }
     }
 }
+

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponseV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponseV2.kt
@@ -1,0 +1,96 @@
+package org.yapp.apis.readingrecord.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.yapp.domain.readingrecord.vo.ReadingRecordInfoVO
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Schema(
+    name = "ReadingRecordResponseV2",
+    description = "독서 기록 응답 (V2)"
+)
+data class ReadingRecordResponseV2 private constructor(
+    @field:Schema(description = "독서 기록 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val id: UUID,
+
+    @field:Schema(description = "사용자 책 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val userBookId: UUID,
+
+    @field:Schema(description = "현재 읽은 페이지 번호 (선택)", example = "42")
+    val pageNumber: Int?,
+
+    @field:Schema(description = "기억에 남는 문장", example = "이것은 기억에 남는 문장입니다.")
+    val quote: String,
+
+    @field:Schema(description = "감상평", example = "이 책은 매우 인상적이었습니다.")
+    val review: String?,
+
+    @field:Schema(description = "대분류 감정")
+    val primaryEmotion: PrimaryEmotionDto,
+
+    @field:Schema(description = "세부 감정 목록")
+    val detailEmotions: List<DetailEmotionDto>,
+
+    @field:Schema(description = "생성 일시", example = "2023-01-01T12:00:00")
+    val createdAt: String,
+
+    @field:Schema(description = "수정 일시", example = "2023-01-01T12:00:00")
+    val updatedAt: String,
+
+    @field:Schema(description = "도서 제목", example = "클린 코드")
+    val bookTitle: String?,
+
+    @field:Schema(description = "출판사", example = "인사이트")
+    val bookPublisher: String?,
+
+    @field:Schema(description = "도서 썸네일 URL", example = "https://example.com/book-cover.jpg")
+    val bookCoverImageUrl: String?,
+
+    @field:Schema(description = "저자", example = "로버트 C. 마틴")
+    val author: String?
+) {
+    companion object {
+        private val dateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
+        fun from(readingRecordInfoVO: ReadingRecordInfoVO): ReadingRecordResponseV2 {
+            return ReadingRecordResponseV2(
+                id = readingRecordInfoVO.id.value,
+                userBookId = readingRecordInfoVO.userBookId.value,
+                pageNumber = readingRecordInfoVO.pageNumber?.value,
+                quote = readingRecordInfoVO.quote.value,
+                review = readingRecordInfoVO.review?.value,
+                primaryEmotion = PrimaryEmotionDto(
+                    code = readingRecordInfoVO.primaryEmotion.name,
+                    displayName = readingRecordInfoVO.primaryEmotion.displayName
+                ),
+                detailEmotions = readingRecordInfoVO.detailEmotions.map {
+                    DetailEmotionDto(id = it.id, name = it.name)
+                },
+                createdAt = readingRecordInfoVO.createdAt.format(dateTimeFormatter),
+                updatedAt = readingRecordInfoVO.updatedAt.format(dateTimeFormatter),
+                bookTitle = readingRecordInfoVO.bookTitle,
+                bookPublisher = readingRecordInfoVO.bookPublisher,
+                bookCoverImageUrl = readingRecordInfoVO.bookCoverImageUrl,
+                author = readingRecordInfoVO.author
+            )
+        }
+    }
+}
+
+@Schema(name = "PrimaryEmotionDto", description = "대분류 감정")
+data class PrimaryEmotionDto(
+    @field:Schema(description = "감정 코드", example = "JOY")
+    val code: String,
+
+    @field:Schema(description = "감정 표시 이름", example = "즐거움")
+    val displayName: String
+)
+
+@Schema(name = "DetailEmotionDto", description = "세부 감정")
+data class DetailEmotionDto(
+    @field:Schema(description = "세부 감정 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    val id: UUID,
+
+    @field:Schema(description = "세부 감정 이름", example = "설레는")
+    val name: String
+)

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponseV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/dto/response/ReadingRecordResponseV2.kt
@@ -59,12 +59,12 @@ data class ReadingRecordResponseV2 private constructor(
                 pageNumber = readingRecordInfoVO.pageNumber?.value,
                 quote = readingRecordInfoVO.quote.value,
                 review = readingRecordInfoVO.review?.value,
-                primaryEmotion = PrimaryEmotionDto(
+                primaryEmotion = PrimaryEmotionDto.of(
                     code = readingRecordInfoVO.primaryEmotion.name,
                     displayName = readingRecordInfoVO.primaryEmotion.displayName
                 ),
                 detailEmotions = readingRecordInfoVO.detailEmotions.map {
-                    DetailEmotionDto(id = it.id, name = it.name)
+                    DetailEmotionDto.of(id = it.id, name = it.name)
                 },
                 createdAt = readingRecordInfoVO.createdAt.format(dateTimeFormatter),
                 updatedAt = readingRecordInfoVO.updatedAt.format(dateTimeFormatter),
@@ -75,22 +75,34 @@ data class ReadingRecordResponseV2 private constructor(
             )
         }
     }
+
+    @Schema(name = "PrimaryEmotionDto", description = "대분류 감정")
+    data class PrimaryEmotionDto private constructor(
+        @field:Schema(description = "감정 코드", example = "JOY")
+        val code: String,
+
+        @field:Schema(description = "감정 표시 이름", example = "즐거움")
+        val displayName: String
+    ) {
+        companion object {
+            fun of(code: String, displayName: String): PrimaryEmotionDto {
+                return PrimaryEmotionDto(code = code, displayName = displayName)
+            }
+        }
+    }
+
+    @Schema(name = "DetailEmotionDto", description = "세부 감정")
+    data class DetailEmotionDto private constructor(
+        @field:Schema(description = "세부 감정 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+        val id: UUID,
+
+        @field:Schema(description = "세부 감정 이름", example = "설레는")
+        val name: String
+    ) {
+        companion object {
+            fun of(id: UUID, name: String): DetailEmotionDto {
+                return DetailEmotionDto(id = id, name = name)
+            }
+        }
+    }
 }
-
-@Schema(name = "PrimaryEmotionDto", description = "대분류 감정")
-data class PrimaryEmotionDto(
-    @field:Schema(description = "감정 코드", example = "JOY")
-    val code: String,
-
-    @field:Schema(description = "감정 표시 이름", example = "즐거움")
-    val displayName: String
-)
-
-@Schema(name = "DetailEmotionDto", description = "세부 감정")
-data class DetailEmotionDto(
-    @field:Schema(description = "세부 감정 ID", example = "123e4567-e89b-12d3-a456-426614174000")
-    val id: UUID,
-
-    @field:Schema(description = "세부 감정 이름", example = "설레는")
-    val name: String
-)

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordService.kt
@@ -79,4 +79,8 @@ class ReadingRecordService(
     ) {
         readingRecordDomainService.deleteReadingRecord(readingRecordId)
     }
+
+    fun getUserBookIdByReadingRecordId(readingRecordId: UUID): UUID {
+        return readingRecordDomainService.findById(readingRecordId).userBookId.value
+    }
 }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordService.kt
@@ -2,6 +2,7 @@ package org.yapp.apis.readingrecord.service
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
 import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequest
 import org.yapp.apis.readingrecord.dto.request.UpdateReadingRecordRequest
 import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponse
@@ -16,6 +17,7 @@ class ReadingRecordService(
     private val readingRecordDomainService: ReadingRecordDomainService,
     private val userDomainService: UserDomainService
 ) {
+    @Transactional
     fun createReadingRecord(
         userId: UUID,
         userBookId: UUID,
@@ -35,6 +37,7 @@ class ReadingRecordService(
         return ReadingRecordResponse.from(readingRecordInfoVO)
     }
 
+    @Transactional(readOnly = true)
     fun getReadingRecordDetail(
         userId: UUID,
         readingRecordId: UUID
@@ -43,6 +46,7 @@ class ReadingRecordService(
         return ReadingRecordResponse.from(readingRecordInfoVO)
     }
 
+    @Transactional(readOnly = true)
     fun getReadingRecordsByDynamicCondition(
         userBookId: UUID,
         sort: ReadingRecordSortType?,
@@ -52,9 +56,12 @@ class ReadingRecordService(
         return page.map { ReadingRecordResponse.from(it) }
     }
 
+    @Transactional
     fun deleteAllByUserBookId(userBookId: UUID) {
         readingRecordDomainService.deleteAllByUserBookId(userBookId)
     }
+
+    @Transactional
     fun updateReadingRecord(
         userId: UUID,
         readingRecordId: UUID,
@@ -74,12 +81,14 @@ class ReadingRecordService(
         return ReadingRecordResponse.from(readingRecordInfoVO)
     }
 
+    @Transactional
     fun deleteReadingRecord(
         readingRecordId: UUID
     ) {
         readingRecordDomainService.deleteReadingRecord(readingRecordId)
     }
 
+    @Transactional(readOnly = true)
     fun getUserBookIdByReadingRecordId(readingRecordId: UUID): UUID {
         return readingRecordDomainService.findById(readingRecordId).userBookId.value
     }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordService.kt
@@ -26,7 +26,7 @@ class ReadingRecordService(
             pageNumber = request.validPageNumber(),
             quote = request.validQuote(),
             review = request.review,
-            emotionTags = request.validEmotionTags()
+            emotionTags = request.emotionTags
         )
 
         // Update user's lastActivity when a reading record is created

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordServiceV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordServiceV2.kt
@@ -1,0 +1,180 @@
+package org.yapp.apis.readingrecord.service
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequestV2
+import org.yapp.apis.readingrecord.dto.request.UpdateReadingRecordRequestV2
+import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponseV2
+import org.yapp.domain.detailtag.DetailTagDomainService
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import org.yapp.domain.readingrecord.ReadingRecord
+import org.yapp.domain.readingrecord.ReadingRecordDomainService
+import org.yapp.domain.readingrecord.ReadingRecordSortType
+import org.yapp.domain.readingrecord.vo.ReadingRecordInfoVO
+import org.yapp.domain.readingrecorddetailtag.ReadingRecordDetailTagDomainService
+import org.yapp.domain.user.UserDomainService
+import org.yapp.globalutils.annotation.ApplicationService
+import java.util.*
+
+@ApplicationService
+class ReadingRecordServiceV2(
+    private val readingRecordDomainService: ReadingRecordDomainService,
+    private val detailTagDomainService: DetailTagDomainService,
+    private val readingRecordDetailTagDomainService: ReadingRecordDetailTagDomainService,
+    private val userDomainService: UserDomainService
+) {
+    fun createReadingRecord(
+        userId: UUID,
+        userBookId: UUID,
+        request: CreateReadingRecordRequestV2
+    ): ReadingRecordResponseV2 {
+        val primaryEmotion = request.validPrimaryEmotion()
+        val detailEmotionTagIds = request.detailEmotionTagIds
+
+        // Validate detail emotion tags belong to the selected primary emotion
+        validateDetailEmotionTags(detailEmotionTagIds, primaryEmotion)
+
+        // Create reading record
+        val savedReadingRecord = readingRecordDomainService.createReadingRecordV2(
+            userBookId = userBookId,
+            pageNumber = request.pageNumber,
+            quote = request.validQuote(),
+            review = request.review,
+            primaryEmotion = primaryEmotion
+        )
+
+        // Save detail emotion tags
+        readingRecordDetailTagDomainService.createAndSaveAll(
+            readingRecordId = savedReadingRecord.id.value,
+            detailTagIds = detailEmotionTagIds
+        )
+
+        // Update user's lastActivity
+        userDomainService.updateLastActivity(userId)
+
+        return buildResponse(savedReadingRecord, detailEmotionTagIds)
+    }
+
+    fun getReadingRecordDetail(
+        readingRecordId: UUID
+    ): ReadingRecordResponseV2 {
+        val readingRecord = readingRecordDomainService.findById(readingRecordId)
+        val detailTagIds = readingRecordDetailTagDomainService.findByReadingRecordId(readingRecordId)
+            .map { it.detailTagId.value }
+
+        return buildResponse(readingRecord, detailTagIds)
+    }
+
+    fun getReadingRecordsByDynamicCondition(
+        userBookId: UUID,
+        sort: ReadingRecordSortType?,
+        pageable: Pageable
+    ): Page<ReadingRecordResponseV2> {
+        val readingRecordPage = readingRecordDomainService.findByDynamicCondition(userBookId, sort, pageable)
+        if (readingRecordPage.isEmpty) {
+            return Page.empty(pageable)
+        }
+
+        val readingRecords = readingRecordPage.content
+        val readingRecordIds = readingRecords.map { it.id.value }
+
+        // Fetch detail tags
+        val readingRecordDetailTags = readingRecordDetailTagDomainService.findByReadingRecordIdIn(readingRecordIds)
+        val detailTagIds = readingRecordDetailTags.map { it.detailTagId.value }.distinct()
+        val detailTagsById = detailTagDomainService.findAllById(detailTagIds).associateBy { it.id.value }
+
+        val detailTagsByReadingRecordId = readingRecordDetailTags
+            .groupBy { it.readingRecordId.value }
+            .mapValues { (_, tags) ->
+                tags.mapNotNull { detailTagsById[it.detailTagId.value] }
+                    .map { ReadingRecordInfoVO.DetailEmotionInfo(it.id.value, it.name) }
+            }
+
+        return readingRecordPage.map { readingRecord ->
+            val detailEmotions = detailTagsByReadingRecordId[readingRecord.id.value] ?: emptyList()
+            ReadingRecordResponseV2.from(
+                ReadingRecordInfoVO.newInstance(
+                    readingRecord = readingRecord,
+                    detailEmotions = detailEmotions
+                )
+            )
+        }
+    }
+
+    fun updateReadingRecord(
+        userId: UUID,
+        readingRecordId: UUID,
+        request: UpdateReadingRecordRequestV2
+    ): ReadingRecordResponseV2 {
+        val existingRecord = readingRecordDomainService.findById(readingRecordId)
+        val newPrimaryEmotion = request.primaryEmotion ?: existingRecord.primaryEmotion
+
+        // Validate detail emotion tags if provided
+        if (!request.detailEmotionTagIds.isNullOrEmpty()) {
+            validateDetailEmotionTags(request.detailEmotionTagIds, newPrimaryEmotion)
+        }
+
+        // Update reading record
+        val savedReadingRecord = readingRecordDomainService.modifyReadingRecordV2(
+            readingRecordId = readingRecordId,
+            pageNumber = request.pageNumber,
+            quote = request.quote,
+            review = request.review,
+            primaryEmotion = request.primaryEmotion
+        )
+
+        // Update detail emotion tags if provided
+        if (request.detailEmotionTagIds != null) {
+            readingRecordDetailTagDomainService.deleteAllByReadingRecordId(readingRecordId)
+            readingRecordDetailTagDomainService.createAndSaveAll(
+                readingRecordId = savedReadingRecord.id.value,
+                detailTagIds = request.detailEmotionTagIds
+            )
+        }
+
+        val finalDetailTagIds = request.detailEmotionTagIds
+            ?: readingRecordDetailTagDomainService.findByReadingRecordId(readingRecordId).map { it.detailTagId.value }
+
+        // Update user's lastActivity
+        userDomainService.updateLastActivity(userId)
+
+        return buildResponse(savedReadingRecord, finalDetailTagIds)
+    }
+
+    fun deleteReadingRecord(readingRecordId: UUID) {
+        readingRecordDetailTagDomainService.deleteAllByReadingRecordId(readingRecordId)
+        readingRecordDomainService.deleteReadingRecordV2(readingRecordId)
+    }
+
+    private fun validateDetailEmotionTags(detailEmotionTagIds: List<UUID>, primaryEmotion: PrimaryEmotion) {
+        if (detailEmotionTagIds.isEmpty()) return
+
+        val detailTags = detailTagDomainService.findAllById(detailEmotionTagIds)
+        require(detailTags.size == detailEmotionTagIds.size) {
+            "Some detail emotion tag IDs are invalid"
+        }
+        require(detailTags.all { it.primaryEmotion == primaryEmotion }) {
+            "All detail emotions must belong to the selected primary emotion"
+        }
+    }
+
+    private fun buildResponse(
+        readingRecord: ReadingRecord,
+        detailTagIds: List<UUID>
+    ): ReadingRecordResponseV2 {
+        val detailEmotions = if (detailTagIds.isNotEmpty()) {
+            detailTagDomainService.findAllById(detailTagIds).map {
+                ReadingRecordInfoVO.DetailEmotionInfo(it.id.value, it.name)
+            }
+        } else {
+            emptyList()
+        }
+
+        return ReadingRecordResponseV2.from(
+            ReadingRecordInfoVO.newInstance(
+                readingRecord = readingRecord,
+                detailEmotions = detailEmotions
+            )
+        )
+    }
+}

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordServiceV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordServiceV2.kt
@@ -2,6 +2,7 @@ package org.yapp.apis.readingrecord.service
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
 import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequestV2
 import org.yapp.apis.readingrecord.dto.request.UpdateReadingRecordRequestV2
 import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponseV2
@@ -23,6 +24,7 @@ class ReadingRecordServiceV2(
     private val readingRecordDetailTagDomainService: ReadingRecordDetailTagDomainService,
     private val userDomainService: UserDomainService
 ) {
+    @Transactional
     fun createReadingRecord(
         userId: UUID,
         userBookId: UUID,
@@ -55,6 +57,7 @@ class ReadingRecordServiceV2(
         return buildResponse(savedReadingRecord, detailEmotionTagIds)
     }
 
+    @Transactional(readOnly = true)
     fun getReadingRecordDetail(
         readingRecordId: UUID
     ): ReadingRecordResponseV2 {
@@ -65,6 +68,7 @@ class ReadingRecordServiceV2(
         return buildResponse(readingRecord, detailTagIds)
     }
 
+    @Transactional(readOnly = true)
     fun getReadingRecordsByDynamicCondition(
         userBookId: UUID,
         sort: ReadingRecordSortType?,
@@ -101,6 +105,7 @@ class ReadingRecordServiceV2(
         }
     }
 
+    @Transactional
     fun updateReadingRecord(
         userId: UUID,
         readingRecordId: UUID,
@@ -137,6 +142,7 @@ class ReadingRecordServiceV2(
         return buildResponse(savedReadingRecord, finalDetailTagIds)
     }
 
+    @Transactional
     fun deleteReadingRecord(readingRecordId: UUID) {
         readingRecordDetailTagDomainService.deleteAllByReadingRecordId(readingRecordId)
         readingRecordDomainService.deleteReadingRecordV2(readingRecordId)
@@ -208,6 +214,7 @@ class ReadingRecordServiceV2(
         )
     }
 
+    @Transactional(readOnly = true)
     fun getUserBookIdByReadingRecordId(readingRecordId: UUID): UUID {
         return readingRecordDomainService.findById(readingRecordId).userBookId.value
     }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordServiceV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordServiceV2.kt
@@ -207,4 +207,8 @@ class ReadingRecordServiceV2(
             )
         )
     }
+
+    fun getUserBookIdByReadingRecordId(readingRecordId: UUID): UUID {
+        return readingRecordDomainService.findById(readingRecordId).userBookId.value
+    }
 }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordServiceV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordServiceV2.kt
@@ -75,7 +75,7 @@ class ReadingRecordServiceV2(
             return Page.empty(pageable)
         }
 
-        val readingRecords = readingRecordPage.content
+        val readingRecords = readingRecordPage.content.toList()
         val readingRecordIds = readingRecords.map { it.id.value }
 
         // Fetch detail tags

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordTagService.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/service/ReadingRecordTagService.kt
@@ -1,5 +1,6 @@
 package org.yapp.apis.readingrecord.service
 
+import org.springframework.transaction.annotation.Transactional
 import org.yapp.apis.readingrecord.dto.response.SeedStatsResponse
 import org.yapp.domain.readingrecordtag.ReadingRecordTagDomainService
 import org.yapp.globalutils.annotation.ApplicationService
@@ -10,6 +11,7 @@ import java.util.*
 class ReadingRecordTagService(
     private val readingRecordTagDomainService: ReadingRecordTagDomainService
 ) {
+    @Transactional(readOnly = true)
     fun getSeedStatsByUserIdAndUserBookId(userId: UUID, userBookId: UUID): SeedStatsResponse {
         val tagStatsVO = readingRecordTagDomainService.countTagsByUserIdAndUserBookIdAndCategories(
             userId = userId,

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCase.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCase.kt
@@ -1,7 +1,7 @@
 package org.yapp.apis.readingrecord.usecase
 
 import org.springframework.data.domain.Pageable
-import org.springframework.transaction.annotation.Transactional
+
 import org.yapp.apis.book.service.UserBookService
 import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequest
 import org.yapp.apis.readingrecord.dto.request.UpdateReadingRecordRequest
@@ -16,14 +16,12 @@ import org.yapp.globalutils.annotation.UseCase
 import java.util.*
 
 @UseCase
-@Transactional(readOnly = true)
 class ReadingRecordUseCase(
     private val readingRecordService: ReadingRecordService,
     private val readingRecordTagService: ReadingRecordTagService,
     private val userService: UserService,
     private val userBookService: UserBookService,
 ) {
-    @Transactional
     fun createReadingRecord(
         userId: UUID,
         userBookId: UUID,
@@ -79,7 +77,7 @@ class ReadingRecordUseCase(
         return readingRecordTagService.getSeedStatsByUserIdAndUserBookId(userId, userBookId)
     }
 
-    @Transactional
+
     fun updateReadingRecord(
         userId: UUID,
         readingRecordId: UUID,
@@ -96,7 +94,6 @@ class ReadingRecordUseCase(
         )
     }
 
-    @Transactional
     fun deleteReadingRecord(
         userId: UUID,
         readingRecordId: UUID

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCase.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCase.kt
@@ -44,6 +44,8 @@ class ReadingRecordUseCase(
         readingRecordId: UUID
     ): ReadingRecordResponse {
         userService.validateUserExists(userId)
+        val userBookId = readingRecordService.getUserBookIdByReadingRecordId(readingRecordId)
+        userBookService.validateUserBookExists(userBookId, userId)
 
         return readingRecordService.getReadingRecordDetail(
             userId = userId,
@@ -84,6 +86,8 @@ class ReadingRecordUseCase(
         request: UpdateReadingRecordRequest
     ): ReadingRecordResponse {
         userService.validateUserExists(userId)
+        val userBookId = readingRecordService.getUserBookIdByReadingRecordId(readingRecordId)
+        userBookService.validateUserBookExists(userBookId, userId)
 
         return readingRecordService.updateReadingRecord(
             userId = userId,
@@ -98,6 +102,8 @@ class ReadingRecordUseCase(
         readingRecordId: UUID
     ) {
         userService.validateUserExists(userId)
+        val userBookId = readingRecordService.getUserBookIdByReadingRecordId(readingRecordId)
+        userBookService.validateUserBookExists(userBookId, userId)
         readingRecordService.deleteReadingRecord(readingRecordId)
     }
 }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCaseV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCaseV2.kt
@@ -2,7 +2,7 @@ package org.yapp.apis.readingrecord.usecase
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.transaction.annotation.Transactional
+
 import org.yapp.apis.book.service.UserBookService
 import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequestV2
 import org.yapp.apis.readingrecord.dto.request.UpdateReadingRecordRequestV2
@@ -14,13 +14,11 @@ import org.yapp.globalutils.annotation.UseCase
 import java.util.*
 
 @UseCase
-@Transactional(readOnly = true)
 class ReadingRecordUseCaseV2(
     private val readingRecordServiceV2: ReadingRecordServiceV2,
     private val userService: UserService,
     private val userBookService: UserBookService,
 ) {
-    @Transactional
     fun createReadingRecord(
         userId: UUID,
         userBookId: UUID,
@@ -64,8 +62,7 @@ class ReadingRecordUseCaseV2(
             pageable = pageable
         )
     }
-
-    @Transactional
+    
     fun updateReadingRecord(
         userId: UUID,
         readingRecordId: UUID,
@@ -82,7 +79,6 @@ class ReadingRecordUseCaseV2(
         )
     }
 
-    @Transactional
     fun deleteReadingRecord(
         userId: UUID,
         readingRecordId: UUID

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCaseV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCaseV2.kt
@@ -41,6 +41,8 @@ class ReadingRecordUseCaseV2(
         readingRecordId: UUID
     ): ReadingRecordResponseV2 {
         userService.validateUserExists(userId)
+        val userBookId = readingRecordServiceV2.getUserBookIdByReadingRecordId(readingRecordId)
+        userBookService.validateUserBookExists(userBookId, userId)
 
         return readingRecordServiceV2.getReadingRecordDetail(
             readingRecordId = readingRecordId
@@ -70,6 +72,8 @@ class ReadingRecordUseCaseV2(
         request: UpdateReadingRecordRequestV2
     ): ReadingRecordResponseV2 {
         userService.validateUserExists(userId)
+        val userBookId = readingRecordServiceV2.getUserBookIdByReadingRecordId(readingRecordId)
+        userBookService.validateUserBookExists(userBookId, userId)
 
         return readingRecordServiceV2.updateReadingRecord(
             userId = userId,
@@ -84,6 +88,8 @@ class ReadingRecordUseCaseV2(
         readingRecordId: UUID
     ) {
         userService.validateUserExists(userId)
+        val userBookId = readingRecordServiceV2.getUserBookIdByReadingRecordId(readingRecordId)
+        userBookService.validateUserBookExists(userBookId, userId)
         readingRecordServiceV2.deleteReadingRecord(readingRecordId)
     }
 }

--- a/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCaseV2.kt
+++ b/apis/src/main/kotlin/org/yapp/apis/readingrecord/usecase/ReadingRecordUseCaseV2.kt
@@ -1,0 +1,89 @@
+package org.yapp.apis.readingrecord.usecase
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+import org.yapp.apis.book.service.UserBookService
+import org.yapp.apis.readingrecord.dto.request.CreateReadingRecordRequestV2
+import org.yapp.apis.readingrecord.dto.request.UpdateReadingRecordRequestV2
+import org.yapp.apis.readingrecord.dto.response.ReadingRecordResponseV2
+import org.yapp.apis.readingrecord.service.ReadingRecordServiceV2
+import org.yapp.apis.user.service.UserService
+import org.yapp.domain.readingrecord.ReadingRecordSortType
+import org.yapp.globalutils.annotation.UseCase
+import java.util.*
+
+@UseCase
+@Transactional(readOnly = true)
+class ReadingRecordUseCaseV2(
+    private val readingRecordServiceV2: ReadingRecordServiceV2,
+    private val userService: UserService,
+    private val userBookService: UserBookService,
+) {
+    @Transactional
+    fun createReadingRecord(
+        userId: UUID,
+        userBookId: UUID,
+        request: CreateReadingRecordRequestV2
+    ): ReadingRecordResponseV2 {
+        userService.validateUserExists(userId)
+        userBookService.validateUserBookExists(userBookId, userId)
+
+        return readingRecordServiceV2.createReadingRecord(
+            userId = userId,
+            userBookId = userBookId,
+            request = request
+        )
+    }
+
+    fun getReadingRecordDetail(
+        userId: UUID,
+        readingRecordId: UUID
+    ): ReadingRecordResponseV2 {
+        userService.validateUserExists(userId)
+
+        return readingRecordServiceV2.getReadingRecordDetail(
+            readingRecordId = readingRecordId
+        )
+    }
+
+    fun getReadingRecordsByUserBookId(
+        userId: UUID,
+        userBookId: UUID,
+        sort: ReadingRecordSortType?,
+        pageable: Pageable
+    ): Page<ReadingRecordResponseV2> {
+        userService.validateUserExists(userId)
+        userBookService.validateUserBookExists(userBookId, userId)
+
+        return readingRecordServiceV2.getReadingRecordsByDynamicCondition(
+            userBookId = userBookId,
+            sort = sort,
+            pageable = pageable
+        )
+    }
+
+    @Transactional
+    fun updateReadingRecord(
+        userId: UUID,
+        readingRecordId: UUID,
+        request: UpdateReadingRecordRequestV2
+    ): ReadingRecordResponseV2 {
+        userService.validateUserExists(userId)
+
+        return readingRecordServiceV2.updateReadingRecord(
+            userId = userId,
+            readingRecordId = readingRecordId,
+            request = request
+        )
+    }
+
+    @Transactional
+    fun deleteReadingRecord(
+        userId: UUID,
+        readingRecordId: UUID
+    ) {
+        userService.validateUserExists(userId)
+        readingRecordServiceV2.deleteReadingRecord(readingRecordId)
+    }
+}

--- a/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTag.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTag.kt
@@ -1,0 +1,58 @@
+package org.yapp.domain.detailtag
+
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import org.yapp.globalutils.util.UuidGenerator
+import java.time.LocalDateTime
+import java.util.*
+
+data class DetailTag private constructor(
+    val id: Id,
+    val primaryEmotion: PrimaryEmotion,
+    val name: String,
+    val displayOrder: Int,
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null
+) {
+    companion object {
+        fun create(
+            primaryEmotion: PrimaryEmotion,
+            name: String,
+            displayOrder: Int
+        ): DetailTag {
+            require(name.isNotBlank()) { "Detail tag name cannot be blank" }
+            require(displayOrder >= 0) { "Display order must be non-negative" }
+
+            return DetailTag(
+                id = Id.newInstance(UuidGenerator.create()),
+                primaryEmotion = primaryEmotion,
+                name = name,
+                displayOrder = displayOrder
+            )
+        }
+
+        fun reconstruct(
+            id: Id,
+            primaryEmotion: PrimaryEmotion,
+            name: String,
+            displayOrder: Int,
+            createdAt: LocalDateTime? = null,
+            updatedAt: LocalDateTime? = null
+        ): DetailTag {
+            return DetailTag(
+                id = id,
+                primaryEmotion = primaryEmotion,
+                name = name,
+                displayOrder = displayOrder,
+                createdAt = createdAt,
+                updatedAt = updatedAt
+            )
+        }
+    }
+
+    @JvmInline
+    value class Id(val value: UUID) {
+        companion object {
+            fun newInstance(value: UUID) = Id(value)
+        }
+    }
+}

--- a/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTagDomainService.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTagDomainService.kt
@@ -1,0 +1,27 @@
+package org.yapp.domain.detailtag
+
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import org.yapp.globalutils.annotation.DomainService
+import java.util.*
+
+@DomainService
+class DetailTagDomainService(
+    private val detailTagRepository: DetailTagRepository
+) {
+    fun findById(id: UUID): DetailTag? {
+        return detailTagRepository.findById(id)
+    }
+
+    fun findAllById(ids: List<UUID>): List<DetailTag> {
+        if (ids.isEmpty()) return emptyList()
+        return detailTagRepository.findAllById(ids)
+    }
+
+    fun findByPrimaryEmotion(primaryEmotion: PrimaryEmotion): List<DetailTag> {
+        return detailTagRepository.findByPrimaryEmotion(primaryEmotion)
+    }
+
+    fun findAll(): List<DetailTag> {
+        return detailTagRepository.findAll()
+    }
+}

--- a/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTagRepository.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTagRepository.kt
@@ -1,0 +1,13 @@
+package org.yapp.domain.detailtag
+
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import java.util.*
+
+interface DetailTagRepository {
+    fun findById(id: UUID): DetailTag?
+    fun findAllById(ids: List<UUID>): List<DetailTag>
+    fun findByPrimaryEmotion(primaryEmotion: PrimaryEmotion): List<DetailTag>
+    fun findAll(): List<DetailTag>
+    fun save(detailTag: DetailTag): DetailTag
+    fun saveAll(detailTags: List<DetailTag>): List<DetailTag>
+}

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecord/PrimaryEmotion.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecord/PrimaryEmotion.kt
@@ -1,0 +1,17 @@
+package org.yapp.domain.readingrecord
+
+enum class PrimaryEmotion(val displayName: String) {
+    WARMTH("따뜻함"),
+    JOY("즐거움"),
+    SADNESS("슬픔"),
+    INSIGHT("깨달음"),
+    OTHER("기타");
+
+    companion object {
+        fun fromDisplayName(name: String): PrimaryEmotion =
+            entries.find { it.displayName == name } ?: OTHER
+
+        fun fromCode(code: String): PrimaryEmotion =
+            entries.find { it.name == code } ?: OTHER
+    }
+}

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecord.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecord.kt
@@ -8,9 +8,10 @@ import java.util.*
 data class ReadingRecord private constructor(
     val id: Id,
     val userBookId: UserBook.Id,
-    val pageNumber: PageNumber,
+    val pageNumber: PageNumber?,
     val quote: Quote,
     val review: Review?,
+    val primaryEmotion: PrimaryEmotion,
     val emotionTags: List<EmotionTag> = emptyList(),
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null,
@@ -19,17 +20,19 @@ data class ReadingRecord private constructor(
     companion object {
         fun create(
             userBookId: UUID,
-            pageNumber: Int,
+            pageNumber: Int?,
             quote: String,
             review: String?,
+            primaryEmotion: PrimaryEmotion,
             emotionTags: List<String> = emptyList()
         ): ReadingRecord {
             return ReadingRecord(
                 id = Id.newInstance(UuidGenerator.create()),
                 userBookId = UserBook.Id.newInstance(userBookId),
-                pageNumber = PageNumber.newInstance(pageNumber),
+                pageNumber = pageNumber?.let { PageNumber.newInstance(it) },
                 quote = Quote.newInstance(quote),
                 review = Review.newInstance(review),
+                primaryEmotion = primaryEmotion,
                 emotionTags = emotionTags.map { EmotionTag.newInstance(it) }
             )
         }
@@ -37,9 +40,10 @@ data class ReadingRecord private constructor(
         fun reconstruct(
             id: Id,
             userBookId: UserBook.Id,
-            pageNumber: PageNumber,
+            pageNumber: PageNumber?,
             quote: Quote,
             review: Review?,
+            primaryEmotion: PrimaryEmotion,
             emotionTags: List<EmotionTag> = emptyList(),
             createdAt: LocalDateTime? = null,
             updatedAt: LocalDateTime? = null,
@@ -51,6 +55,7 @@ data class ReadingRecord private constructor(
                 pageNumber = pageNumber,
                 quote = quote,
                 review = review,
+                primaryEmotion = primaryEmotion,
                 emotionTags = emotionTags,
                 createdAt = createdAt,
                 updatedAt = updatedAt,
@@ -63,12 +68,14 @@ data class ReadingRecord private constructor(
         pageNumber: Int?,
         quote: String?,
         review: String?,
+        primaryEmotion: PrimaryEmotion?,
         emotionTags: List<String>?
     ): ReadingRecord {
         return this.copy(
             pageNumber = pageNumber?.let { PageNumber.newInstance(it) } ?: this.pageNumber,
             quote = quote?.let { Quote.newInstance(it) } ?: this.quote,
             review = if (review != null) Review.newInstance(review) else this.review,
+            primaryEmotion = primaryEmotion ?: this.primaryEmotion,
             emotionTags = emotionTags?.map { EmotionTag.newInstance(it) } ?: this.emotionTags,
             updatedAt = LocalDateTime.now()
         )

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecord/vo/ReadingRecordInfoVO.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecord/vo/ReadingRecordInfoVO.kt
@@ -1,16 +1,20 @@
 package org.yapp.domain.readingrecord.vo
 
+import org.yapp.domain.readingrecord.PrimaryEmotion
 import org.yapp.domain.readingrecord.ReadingRecord
 import org.yapp.domain.userbook.UserBook
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class ReadingRecordInfoVO private constructor(
     val id: ReadingRecord.Id,
     val userBookId: UserBook.Id,
-    val pageNumber: ReadingRecord.PageNumber,
+    val pageNumber: ReadingRecord.PageNumber?,
     val quote: ReadingRecord.Quote,
     val review: ReadingRecord.Review?,
+    val primaryEmotion: PrimaryEmotion,
     val emotionTags: List<String>,
+    val detailEmotions: List<DetailEmotionInfo>,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
     val bookTitle: String? = null,
@@ -19,7 +23,6 @@ data class ReadingRecordInfoVO private constructor(
     val author: String? = null
 ) {
     init {
-        require(emotionTags.size <= 3) { "Maximum 3 emotion tags are allowed" }
         require(!createdAt.isAfter(updatedAt)) {
             "생성일(createdAt)은 수정일(updatedAt)보다 이후일 수 없습니다."
         }
@@ -28,7 +31,8 @@ data class ReadingRecordInfoVO private constructor(
     companion object {
         fun newInstance(
             readingRecord: ReadingRecord,
-            emotionTags: List<String>,
+            emotionTags: List<String> = emptyList(),
+            detailEmotions: List<DetailEmotionInfo> = emptyList(),
             bookTitle: String? = null,
             bookPublisher: String? = null,
             bookCoverImageUrl: String? = null,
@@ -40,7 +44,9 @@ data class ReadingRecordInfoVO private constructor(
                 pageNumber = readingRecord.pageNumber,
                 quote = readingRecord.quote,
                 review = readingRecord.review,
+                primaryEmotion = readingRecord.primaryEmotion,
                 emotionTags = emotionTags,
+                detailEmotions = detailEmotions,
                 createdAt = readingRecord.createdAt ?: throw IllegalStateException("createdAt은 null일 수 없습니다."),
                 updatedAt = readingRecord.updatedAt ?: throw IllegalStateException("updatedAt은 null일 수 없습니다."),
                 bookTitle = bookTitle,
@@ -50,4 +56,9 @@ data class ReadingRecordInfoVO private constructor(
             )
         }
     }
+
+    data class DetailEmotionInfo(
+        val id: UUID,
+        val name: String
+    )
 }

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecorddetailtag/ReadingRecordDetailTag.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecorddetailtag/ReadingRecordDetailTag.kt
@@ -1,0 +1,55 @@
+package org.yapp.domain.readingrecorddetailtag
+
+import org.yapp.domain.detailtag.DetailTag
+import org.yapp.domain.readingrecord.ReadingRecord
+import org.yapp.globalutils.util.UuidGenerator
+import java.time.LocalDateTime
+import java.util.*
+
+data class ReadingRecordDetailTag private constructor(
+    val id: Id,
+    val readingRecordId: ReadingRecord.Id,
+    val detailTagId: DetailTag.Id,
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null,
+    val deletedAt: LocalDateTime? = null
+) {
+    companion object {
+        fun create(
+            readingRecordId: UUID,
+            detailTagId: UUID
+        ): ReadingRecordDetailTag {
+            return ReadingRecordDetailTag(
+                id = Id.newInstance(UuidGenerator.create()),
+                readingRecordId = ReadingRecord.Id.newInstance(readingRecordId),
+                detailTagId = DetailTag.Id.newInstance(detailTagId)
+            )
+        }
+
+        fun reconstruct(
+            id: Id,
+            readingRecordId: ReadingRecord.Id,
+            detailTagId: DetailTag.Id,
+            createdAt: LocalDateTime? = null,
+            updatedAt: LocalDateTime? = null,
+            deletedAt: LocalDateTime? = null
+        ): ReadingRecordDetailTag {
+            return ReadingRecordDetailTag(
+                id = id,
+                readingRecordId = readingRecordId,
+                detailTagId = detailTagId,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+                deletedAt = deletedAt
+            )
+        }
+    }
+
+    @JvmInline
+    value class Id(val value: UUID) {
+        companion object {
+            fun newInstance(value: UUID) = Id(value)
+        }
+    }
+}
+

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecorddetailtag/ReadingRecordDetailTagDomainService.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecorddetailtag/ReadingRecordDetailTagDomainService.kt
@@ -1,0 +1,34 @@
+package org.yapp.domain.readingrecorddetailtag
+
+import org.yapp.globalutils.annotation.DomainService
+import java.util.*
+
+@DomainService
+class ReadingRecordDetailTagDomainService(
+    private val readingRecordDetailTagRepository: ReadingRecordDetailTagRepository
+) {
+    fun findByReadingRecordId(readingRecordId: UUID): List<ReadingRecordDetailTag> {
+        return readingRecordDetailTagRepository.findByReadingRecordId(readingRecordId)
+    }
+
+    fun findByReadingRecordIdIn(readingRecordIds: List<UUID>): List<ReadingRecordDetailTag> {
+        if (readingRecordIds.isEmpty()) return emptyList()
+        return readingRecordDetailTagRepository.findByReadingRecordIdIn(readingRecordIds)
+    }
+
+    fun deleteAllByReadingRecordId(readingRecordId: UUID) {
+        readingRecordDetailTagRepository.deleteAllByReadingRecordId(readingRecordId)
+    }
+
+    fun createAndSaveAll(readingRecordId: UUID, detailTagIds: List<UUID>): List<ReadingRecordDetailTag> {
+        if (detailTagIds.isEmpty()) return emptyList()
+        val readingRecordDetailTags = detailTagIds.map { detailTagId ->
+            ReadingRecordDetailTag.create(
+                readingRecordId = readingRecordId,
+                detailTagId = detailTagId
+            )
+        }
+        return readingRecordDetailTagRepository.saveAll(readingRecordDetailTags)
+    }
+}
+

--- a/domain/src/main/kotlin/org/yapp/domain/readingrecorddetailtag/ReadingRecordDetailTagRepository.kt
+++ b/domain/src/main/kotlin/org/yapp/domain/readingrecorddetailtag/ReadingRecordDetailTagRepository.kt
@@ -1,0 +1,11 @@
+package org.yapp.domain.readingrecorddetailtag
+
+import java.util.*
+
+interface ReadingRecordDetailTagRepository {
+    fun findByReadingRecordId(readingRecordId: UUID): List<ReadingRecordDetailTag>
+    fun findByReadingRecordIdIn(readingRecordIds: List<UUID>): List<ReadingRecordDetailTag>
+    fun save(readingRecordDetailTag: ReadingRecordDetailTag): ReadingRecordDetailTag
+    fun saveAll(readingRecordDetailTags: List<ReadingRecordDetailTag>): List<ReadingRecordDetailTag>
+    fun deleteAllByReadingRecordId(readingRecordId: UUID)
+}

--- a/infra/src/main/kotlin/org/yapp/infra/detailtag/entity/DetailTagEntity.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/detailtag/entity/DetailTagEntity.kt
@@ -1,0 +1,73 @@
+package org.yapp.infra.detailtag.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.JdbcTypeCode
+import org.yapp.domain.detailtag.DetailTag
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import org.yapp.infra.common.BaseTimeEntity
+import java.sql.Types
+import java.util.*
+
+@Entity
+@Table(
+    name = "detail_tags",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uq_detail_tags_emotion_name",
+            columnNames = ["primary_emotion", "name"]
+        )
+    ]
+)
+class DetailTagEntity(
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Column(length = 36, updatable = false, nullable = false)
+    val id: UUID,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "primary_emotion", nullable = false, length = 20)
+    val primaryEmotion: PrimaryEmotion,
+
+    name: String,
+    displayOrder: Int = 0
+) : BaseTimeEntity() {
+
+    @Column(nullable = false, length = 20)
+    var name: String = name
+        protected set
+
+    @Column(name = "display_order", nullable = false)
+    var displayOrder: Int = displayOrder
+        protected set
+
+    fun toDomain(): DetailTag {
+        return DetailTag.reconstruct(
+            id = DetailTag.Id.newInstance(this.id),
+            primaryEmotion = this.primaryEmotion,
+            name = this.name,
+            displayOrder = this.displayOrder,
+            createdAt = this.createdAt,
+            updatedAt = this.updatedAt
+        )
+    }
+
+    companion object {
+        fun fromDomain(detailTag: DetailTag): DetailTagEntity {
+            return DetailTagEntity(
+                id = detailTag.id.value,
+                primaryEmotion = detailTag.primaryEmotion,
+                name = detailTag.name,
+                displayOrder = detailTag.displayOrder
+            )
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DetailTagEntity) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+}
+

--- a/infra/src/main/kotlin/org/yapp/infra/detailtag/repository/DetailTagRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/detailtag/repository/DetailTagRepositoryImpl.kt
@@ -1,0 +1,45 @@
+package org.yapp.infra.detailtag.repository
+
+import org.springframework.stereotype.Repository
+import org.yapp.domain.detailtag.DetailTag
+import org.yapp.domain.detailtag.DetailTagRepository
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import org.yapp.infra.detailtag.entity.DetailTagEntity
+import java.util.*
+
+@Repository
+class DetailTagRepositoryImpl(
+    private val jpaDetailTagRepository: JpaDetailTagRepository
+) : DetailTagRepository {
+
+    override fun findById(id: UUID): DetailTag? {
+        return jpaDetailTagRepository.findById(id)
+            .map { it.toDomain() }
+            .orElse(null)
+    }
+
+    override fun findAllById(ids: List<UUID>): List<DetailTag> {
+        return jpaDetailTagRepository.findAllById(ids)
+            .map { it.toDomain() }
+    }
+
+    override fun findByPrimaryEmotion(primaryEmotion: PrimaryEmotion): List<DetailTag> {
+        return jpaDetailTagRepository.findByPrimaryEmotionOrderByDisplayOrderAsc(primaryEmotion)
+            .map { it.toDomain() }
+    }
+
+    override fun findAll(): List<DetailTag> {
+        return jpaDetailTagRepository.findAllByOrderByPrimaryEmotionAscDisplayOrderAsc()
+            .map { it.toDomain() }
+    }
+
+    override fun save(detailTag: DetailTag): DetailTag {
+        val entity = DetailTagEntity.fromDomain(detailTag)
+        return jpaDetailTagRepository.save(entity).toDomain()
+    }
+
+    override fun saveAll(detailTags: List<DetailTag>): List<DetailTag> {
+        val entities = detailTags.map { DetailTagEntity.fromDomain(it) }
+        return jpaDetailTagRepository.saveAll(entities).map { it.toDomain() }
+    }
+}

--- a/infra/src/main/kotlin/org/yapp/infra/detailtag/repository/JpaDetailTagRepository.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/detailtag/repository/JpaDetailTagRepository.kt
@@ -1,0 +1,12 @@
+package org.yapp.infra.detailtag.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.yapp.domain.readingrecord.PrimaryEmotion
+import org.yapp.infra.detailtag.entity.DetailTagEntity
+import java.util.*
+
+interface JpaDetailTagRepository : JpaRepository<DetailTagEntity, UUID> {
+    fun findByPrimaryEmotionOrderByDisplayOrderAsc(primaryEmotion: PrimaryEmotion): List<DetailTagEntity>
+    fun findAllByOrderByPrimaryEmotionAscDisplayOrderAsc(): List<DetailTagEntity>
+}
+

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecord/entity/ReadingRecordEntity.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecord/entity/ReadingRecordEntity.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.*
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
+import org.yapp.domain.readingrecord.PrimaryEmotion
 import org.yapp.domain.readingrecord.ReadingRecord
 import org.yapp.domain.userbook.UserBook
 import org.yapp.infra.common.BaseTimeEntity
@@ -24,15 +25,14 @@ class ReadingRecordEntity(
     @JdbcTypeCode(Types.VARCHAR)
     val userBookId: UUID,
 
-    pageNumber: Int,
+    pageNumber: Int?,
     quote: String,
     review: String?,
-
-    
+    primaryEmotion: PrimaryEmotion
 ) : BaseTimeEntity() {
 
-    @Column(name = "page_number", nullable = false)
-    var pageNumber: Int = pageNumber
+    @Column(name = "page_number", nullable = true)
+    var pageNumber: Int? = pageNumber
         protected set
 
     @Column(name = "quote", nullable = false, length = 1000)
@@ -43,13 +43,19 @@ class ReadingRecordEntity(
     var review: String? = review
         protected set
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "primary_emotion", nullable = false, length = 20)
+    var primaryEmotion: PrimaryEmotion = primaryEmotion
+        protected set
+
     fun toDomain(): ReadingRecord {
         return ReadingRecord.reconstruct(
             id = ReadingRecord.Id.newInstance(this.id),
             userBookId = UserBook.Id.newInstance(this.userBookId),
-            pageNumber = ReadingRecord.PageNumber.newInstance(this.pageNumber),
+            pageNumber = this.pageNumber?.let { ReadingRecord.PageNumber.newInstance(it) },
             quote = ReadingRecord.Quote.newInstance(this.quote),
             review = ReadingRecord.Review.newInstance(this.review),
+            primaryEmotion = this.primaryEmotion,
             emotionTags = emptyList(),
             createdAt = this.createdAt,
             updatedAt = this.updatedAt,
@@ -62,9 +68,10 @@ class ReadingRecordEntity(
             return ReadingRecordEntity(
                 id = readingRecord.id.value,
                 userBookId = readingRecord.userBookId.value,
-                pageNumber = readingRecord.pageNumber.value,
+                pageNumber = readingRecord.pageNumber?.value,
                 quote = readingRecord.quote.value,
-                review = readingRecord.review?.value
+                review = readingRecord.review?.value,
+                primaryEmotion = readingRecord.primaryEmotion
             )
         }
     }

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecorddetailtag/entity/ReadingRecordDetailTagEntity.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecorddetailtag/entity/ReadingRecordDetailTagEntity.kt
@@ -1,0 +1,73 @@
+package org.yapp.infra.readingrecorddetailtag.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+import org.yapp.domain.detailtag.DetailTag
+import org.yapp.domain.readingrecord.ReadingRecord
+import org.yapp.domain.readingrecorddetailtag.ReadingRecordDetailTag
+import org.yapp.infra.common.BaseTimeEntity
+import java.sql.Types
+import java.util.*
+
+@Entity
+@Table(
+    name = "reading_record_detail_tags",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uq_record_detail_tag",
+            columnNames = ["reading_record_id", "detail_tag_id"]
+        )
+    ],
+    indexes = [
+        Index(name = "idx_rrdt_reading_record_id", columnList = "reading_record_id"),
+        Index(name = "idx_rrdt_detail_tag_id", columnList = "detail_tag_id")
+    ]
+)
+@SQLDelete(sql = "UPDATE reading_record_detail_tags SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+class ReadingRecordDetailTagEntity(
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Column(length = 36, updatable = false, nullable = false)
+    val id: UUID,
+
+    @Column(name = "reading_record_id", nullable = false, length = 36)
+    @JdbcTypeCode(Types.VARCHAR)
+    val readingRecordId: UUID,
+
+    @Column(name = "detail_tag_id", nullable = false, length = 36)
+    @JdbcTypeCode(Types.VARCHAR)
+    val detailTagId: UUID
+) : BaseTimeEntity() {
+
+    fun toDomain(): ReadingRecordDetailTag {
+        return ReadingRecordDetailTag.reconstruct(
+            id = ReadingRecordDetailTag.Id.newInstance(this.id),
+            readingRecordId = ReadingRecord.Id.newInstance(this.readingRecordId),
+            detailTagId = DetailTag.Id.newInstance(this.detailTagId),
+            createdAt = this.createdAt,
+            updatedAt = this.updatedAt,
+            deletedAt = this.deletedAt
+        )
+    }
+
+    companion object {
+        fun fromDomain(readingRecordDetailTag: ReadingRecordDetailTag): ReadingRecordDetailTagEntity {
+            return ReadingRecordDetailTagEntity(
+                id = readingRecordDetailTag.id.value,
+                readingRecordId = readingRecordDetailTag.readingRecordId.value,
+                detailTagId = readingRecordDetailTag.detailTagId.value
+            )
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ReadingRecordDetailTagEntity) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+}

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecorddetailtag/repository/JpaReadingRecordDetailTagRepository.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecorddetailtag/repository/JpaReadingRecordDetailTagRepository.kt
@@ -1,0 +1,12 @@
+package org.yapp.infra.readingrecorddetailtag.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.yapp.infra.readingrecorddetailtag.entity.ReadingRecordDetailTagEntity
+import java.util.*
+
+interface JpaReadingRecordDetailTagRepository : JpaRepository<ReadingRecordDetailTagEntity, UUID> {
+    fun findByReadingRecordId(readingRecordId: UUID): List<ReadingRecordDetailTagEntity>
+    fun findByReadingRecordIdIn(readingRecordIds: List<UUID>): List<ReadingRecordDetailTagEntity>
+    fun deleteAllByReadingRecordId(readingRecordId: UUID)
+}
+

--- a/infra/src/main/kotlin/org/yapp/infra/readingrecorddetailtag/repository/ReadingRecordDetailTagRepositoryImpl.kt
+++ b/infra/src/main/kotlin/org/yapp/infra/readingrecorddetailtag/repository/ReadingRecordDetailTagRepositoryImpl.kt
@@ -1,0 +1,39 @@
+package org.yapp.infra.readingrecorddetailtag.repository
+
+import org.springframework.stereotype.Repository
+import org.yapp.domain.readingrecorddetailtag.ReadingRecordDetailTag
+import org.yapp.domain.readingrecorddetailtag.ReadingRecordDetailTagRepository
+import org.yapp.infra.readingrecorddetailtag.entity.ReadingRecordDetailTagEntity
+import java.util.*
+
+@Repository
+class ReadingRecordDetailTagRepositoryImpl(
+    private val jpaReadingRecordDetailTagRepository: JpaReadingRecordDetailTagRepository
+) : ReadingRecordDetailTagRepository {
+
+    override fun findByReadingRecordId(readingRecordId: UUID): List<ReadingRecordDetailTag> {
+        return jpaReadingRecordDetailTagRepository.findByReadingRecordId(readingRecordId)
+            .map { it.toDomain() }
+    }
+
+    override fun findByReadingRecordIdIn(readingRecordIds: List<UUID>): List<ReadingRecordDetailTag> {
+        if (readingRecordIds.isEmpty()) return emptyList()
+        return jpaReadingRecordDetailTagRepository.findByReadingRecordIdIn(readingRecordIds)
+            .map { it.toDomain() }
+    }
+
+    override fun save(readingRecordDetailTag: ReadingRecordDetailTag): ReadingRecordDetailTag {
+        val entity = ReadingRecordDetailTagEntity.fromDomain(readingRecordDetailTag)
+        return jpaReadingRecordDetailTagRepository.save(entity).toDomain()
+    }
+
+    override fun saveAll(readingRecordDetailTags: List<ReadingRecordDetailTag>): List<ReadingRecordDetailTag> {
+        if (readingRecordDetailTags.isEmpty()) return emptyList()
+        val entities = readingRecordDetailTags.map { ReadingRecordDetailTagEntity.fromDomain(it) }
+        return jpaReadingRecordDetailTagRepository.saveAll(entities).map { it.toDomain() }
+    }
+
+    override fun deleteAllByReadingRecordId(readingRecordId: UUID) {
+        jpaReadingRecordDetailTagRepository.deleteAllByReadingRecordId(readingRecordId)
+    }
+}

--- a/infra/src/main/resources/db/migration/mysql/V20251224_001__add_primary_emotion_and_detail_tags.sql
+++ b/infra/src/main/resources/db/migration/mysql/V20251224_001__add_primary_emotion_and_detail_tags.sql
@@ -1,0 +1,85 @@
+-- 1. reading_records 테이블 수정
+-- page_number를 nullable로 변경
+ALTER TABLE reading_records MODIFY COLUMN page_number INT NULL;
+
+-- primary_emotion 컬럼 추가
+ALTER TABLE reading_records ADD COLUMN primary_emotion VARCHAR(20) NULL;
+
+-- 기존 데이터 마이그레이션 (tags 기반으로 primary_emotion 설정)
+UPDATE reading_records rr
+SET primary_emotion = COALESCE(
+    (SELECT CASE t.name
+        WHEN '따뜻함' THEN 'WARMTH'
+        WHEN '즐거움' THEN 'JOY'
+        WHEN '슬픔' THEN 'SADNESS'
+        WHEN '깨달음' THEN 'INSIGHT'
+        ELSE 'OTHER'
+    END
+    FROM reading_record_tags rrt
+    JOIN tags t ON rrt.tag_id = t.id
+    WHERE rrt.reading_record_id = rr.id AND rrt.deleted_at IS NULL
+    LIMIT 1),
+    'OTHER'
+);
+
+-- NOT NULL 제약 추가
+ALTER TABLE reading_records MODIFY COLUMN primary_emotion VARCHAR(20) NOT NULL;
+
+-- 2. detail_tags 테이블 생성
+CREATE TABLE detail_tags (
+    id              VARCHAR(36) NOT NULL,
+    created_at      datetime(6) NOT NULL,
+    updated_at      datetime(6) NOT NULL,
+    primary_emotion VARCHAR(20) NOT NULL,
+    name            VARCHAR(20) NOT NULL,
+    display_order   INT NOT NULL DEFAULT 0,
+    CONSTRAINT pk_detail_tags PRIMARY KEY (id),
+    CONSTRAINT uq_detail_tags_emotion_name UNIQUE (primary_emotion, name)
+);
+
+-- 3. reading_record_detail_tags 테이블 생성
+CREATE TABLE reading_record_detail_tags (
+    id                  VARCHAR(36) NOT NULL,
+    created_at          datetime(6) NOT NULL,
+    updated_at          datetime(6) NOT NULL,
+    deleted_at          datetime(6) NULL,
+    reading_record_id   VARCHAR(36) NOT NULL,
+    detail_tag_id       VARCHAR(36) NOT NULL,
+    CONSTRAINT pk_reading_record_detail_tags PRIMARY KEY (id),
+    CONSTRAINT uq_record_detail_tag UNIQUE (reading_record_id, detail_tag_id),
+    CONSTRAINT fk_rrdt_reading_record FOREIGN KEY (reading_record_id) REFERENCES reading_records(id) ON DELETE CASCADE,
+    CONSTRAINT fk_rrdt_detail_tag FOREIGN KEY (detail_tag_id) REFERENCES detail_tags(id)
+);
+
+CREATE INDEX idx_rrdt_reading_record_id ON reading_record_detail_tags(reading_record_id);
+CREATE INDEX idx_rrdt_detail_tag_id ON reading_record_detail_tags(detail_tag_id);
+
+-- 4. 세부감정 초기 데이터 삽입
+INSERT INTO detail_tags (id, created_at, updated_at, primary_emotion, name, display_order) VALUES
+-- 즐거움
+(UUID(), NOW(), NOW(), 'JOY', '설레는', 1),
+(UUID(), NOW(), NOW(), 'JOY', '뿌듯한', 2),
+(UUID(), NOW(), NOW(), 'JOY', '유쾌한', 3),
+(UUID(), NOW(), NOW(), 'JOY', '기쁜', 4),
+(UUID(), NOW(), NOW(), 'JOY', '흥미진진한', 5),
+-- 따뜻함
+(UUID(), NOW(), NOW(), 'WARMTH', '위로받은', 1),
+(UUID(), NOW(), NOW(), 'WARMTH', '포근한', 2),
+(UUID(), NOW(), NOW(), 'WARMTH', '다정한', 3),
+(UUID(), NOW(), NOW(), 'WARMTH', '고마운', 4),
+(UUID(), NOW(), NOW(), 'WARMTH', '마음이 놓이는', 5),
+(UUID(), NOW(), NOW(), 'WARMTH', '편안한', 6),
+-- 슬픔
+(UUID(), NOW(), NOW(), 'SADNESS', '허무한', 1),
+(UUID(), NOW(), NOW(), 'SADNESS', '외로운', 2),
+(UUID(), NOW(), NOW(), 'SADNESS', '아쉬운', 3),
+(UUID(), NOW(), NOW(), 'SADNESS', '먹먹한', 4),
+(UUID(), NOW(), NOW(), 'SADNESS', '애틋한', 5),
+(UUID(), NOW(), NOW(), 'SADNESS', '안타까운', 6),
+(UUID(), NOW(), NOW(), 'SADNESS', '그리운', 7),
+-- 깨달음
+(UUID(), NOW(), NOW(), 'INSIGHT', '감탄한', 1),
+(UUID(), NOW(), NOW(), 'INSIGHT', '통찰력을 얻은', 2),
+(UUID(), NOW(), NOW(), 'INSIGHT', '영감을 받은', 3),
+(UUID(), NOW(), NOW(), 'INSIGHT', '생각이 깊어진', 4),
+(UUID(), NOW(), NOW(), 'INSIGHT', '새롭게 이해한', 5);


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #145

## 📘 작업 유형
- [x] ✨ Feature (기능 추가)
- [ ] 🐞 Bugfix (버그 수정)
- [x] 🔧 Refactor (코드 리팩토링)
- [ ] ⚙️ Chore (환경 설정)
- [ ] 📝 Docs (문서 작성 및 수정)
- [ ] ✅ Test (기능 테스트)
- [ ] 🎨 style (코드 스타일 수정)

## 📙 작업 내역
### 감정 시스템 V2 구조
- 대분류 감정 5개: 따뜻함, 즐거움, 슬픔, 깨달음, 기타
- 세부 감정 태그: 대분류별 여러 세부 감정 지원 (다중 선택 가능)

### Domain Layer
- [PrimaryEmotion](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/domain/src/main/kotlin/org/yapp/domain/readingrecord/PrimaryEmotion.kt:2:0-16:1) enum 추가 (대분류 감정)
- [DetailTag](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTag.kt:7:0-57:1) 도메인 및 Repository 추가 (세부 감정)
- [ReadingRecordDetailTag](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/infra/src/main/kotlin/org/yapp/infra/readingrecorddetailtag/entity/ReadingRecordDetailTagEntity.kt:13:0-72:1) 도메인 및 Repository 추가 (독서기록-세부감정 연결)
- [DetailTagDomainService](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTagDomainService.kt:6:0-26:1), [ReadingRecordDetailTagDomainService](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/domain/src/main/kotlin/org/yapp/domain/readingrecorddetailtag/ReadingRecordDetailTagDomainService.kt:5:0-32:1) 추가
- [ReadingRecord](cci:1://file:///Users/mgrv/Desktop/mgrv/Reed-Server/apis/src/main/kotlin/org/yapp/apis/readingrecord/controller/ReadingRecordControllerV2.kt:50:4-65:5)에 `primaryEmotion` 필드 추가, `pageNumber` nullable 변경

### Infra Layer
- DB 마이그레이션 스크립트 추가 (`V20251224_001`)
  - `detail_tags` 테이블 생성
  - `reading_record_detail_tags` 테이블 생성
  - `reading_records.primary_emotion` 컬럼 추가
- [DetailTagEntity](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/infra/src/main/kotlin/org/yapp/infra/detailtag/entity/DetailTagEntity.kt:10:0-71:1), [ReadingRecordDetailTagEntity](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/infra/src/main/kotlin/org/yapp/infra/readingrecorddetailtag/entity/ReadingRecordDetailTagEntity.kt:13:0-72:1) 추가
- Repository 구현체 추가

### APIs Layer (V2)
- `POST /api/v2/reading-records/{userBookId}` - 독서 기록 생성
- `GET /api/v2/reading-records/detail/{readingRecordId}` - 독서 기록 상세 조회
- `GET /api/v2/reading-records/{userBookId}` - 독서 기록 목록 조회
- `PUT /api/v2/reading-records/{readingRecordId}` - 독서 기록 수정
- `DELETE /api/v2/reading-records/{readingRecordId}` - 독서 기록 삭제
- `GET /api/v2/emotions` - 감정 목록 조회 API

### DTO 리팩토링
- V2 DTO에 private constructor + 정적 팩토리 메서드 패턴 일관성 있게 적용
- PrimaryEmotionDto, DetailEmotionDto, EmotionGroupDto, EmotionDetailDto를 nested class로 리팩토링
- CreateReadingRecordRequestV2에 @NotNull validation 추가

### primaryEmotion 변경 시 데이터 일관성 보장
- 대분류 감정 변경 시 세부 감정 태그 처리 로직 추가
- 대분류 변경 + 새 태그 제공 → 새 태그로 교체
- 대분류 변경 + 태그 미제공 → 기존 태그 삭제 (불일치 방지)
- 대분류 유지 + 새 태그 제공 → 새 태그로 교체
- 대분류 유지 + 태그 미제공 → 기존 태그 유지

### 소유권 검증 강화 (V1/V2 공통)
- getReadingRecordDetail, updateReadingRecord, deleteReadingRecord에 소유권 검증 추가
- USER_BOOK_ACCESS_DENIED (403 FORBIDDEN) 에러 코드 추가
- 다른 사용자의 독서 기록에 무단 접근 시 403 반환

### API 문서 개선
- 정렬 파라미터 우선순위 명확화 (sort 파라미터 vs Pageable.sort)
- pageNumber 필드에 "(선택)" 표시 추가

### V1 호환성
- 기존 V1 API는 그대로 유지
- V1 Response의 pageNumber nullable 변경
- V1에도 동일한 소유권 검증 적용

## 🧪 테스트 내역
- [x] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## ✅ PR 체크리스트
- [x] 커밋 메시지가 명확합니다
- [x] PR 제목이 컨벤션에 맞습니다
- [x] 관련 이슈 번호를 작성했습니다
- [x] 기능이 정상적으로 작동합니다
- [x] 불필요한 코드를 제거했습니다

## 💬 추가 설명 or 리뷰 포인트
- **커밋 구조**: 17개 커밋이 구현 논리 순서대로 작성되어 있어 코드 리뷰 시 흐름 파악이 용이합니다
- **DomainService 분리**: V2에서는 `ApplicationService`가 여러 [DomainService](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/domain/src/main/kotlin/org/yapp/domain/detailtag/DetailTagDomainService.kt:6:0-26:1)를 조합하는 구조로 설계했습니다
- **TODO**: [ReadingRecordDomainService](cci:2://file:///Users/mgrv/Desktop/mgrv/Reed-Server/domain/src/main/kotlin/org/yapp/domain/readingrecord/ReadingRecordDomainService.kt:18:0-296:1)의 V1 관련 의존성은 추후 분리 예정 (주석 표시됨)
- **세부 감정 데이터**: 마이그레이션에서 초기 세부 감정 데이터가 INSERT됩니다
- **보안 강화**: V1/V2 모두 독서 기록 접근 시 소유권 검증 추가 (403 FORBIDDEN)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 감정 목록 조회 API 추가
  * 독서기록 V2 API 도입(주감정·세부감정 태그 지원, CRUD, 페이징/정렬)

* **Enhancements**
  * 요청/응답 포맷 확장: 주감정, 세부감정 포함 및 pageNumber 선택형 처리
  * 세부감정(DetailTag) 도입 및 연결 테이블·관리 로직 추가
  * 마이그레이션으로 기존 데이터에 주감정 칼럼 및 초기 세부감정 데이터 추가

* **Bug Fixes / Changes**
  * 사용자 책 권한 오류 코드 및 메시지 변경 (접근 거부)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->